### PR TITLE
Support writing corelib with Shiika

### DIFF
--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -53,18 +53,7 @@ impl<'a> HirMaker<'a> {
     fn to_hir(&mut self,
            sk_methods: HashMap<ClassFullname, Vec<SkMethod>>,
            mut main_exprs: HirExpressions) -> Hir {
-        let mut sk_classes = HashMap::new();
-        self.index.classes.iter().for_each(|(name, c)| {
-            let ivars = self.class_ivars.get(name).expect(&format!("[BUG] ivars for class {} not found", name));
-            // PERF: How to avoid these clone's? Use Rc?
-            sk_classes.insert(name.clone(), SkClass {
-                fullname: c.fullname.clone(),
-                superclass_fullname: c.superclass_fullname.clone(),
-                instance_ty: c.instance_ty.clone(),
-                ivars: Rc::clone(&ivars),
-                method_sigs: c.method_sigs.clone()
-            });
-        });
+        let sk_classes = self.extract_classes();
 
         // Extract data from self
         let mut constants = HashMap::new();
@@ -86,6 +75,27 @@ impl<'a> HirMaker<'a> {
             }
         }
     }
+
+    fn extract_classes(&mut self) -> HashMap<ClassFullname, SkClass> {
+        // TODO: Extract index
+        //let mut index = Index::new();
+        //std::mem::swap(&mut index, &mut self.index);
+
+        let mut sk_classes = HashMap::new();
+        self.index.classes.iter().for_each(|(name, c)| {
+            let ivars = self.class_ivars.get(name).expect(&format!("[BUG] ivars for class {} not found", name));
+            // PERF: How to avoid these clone's? Use Rc?
+            sk_classes.insert(name.clone(), SkClass {
+                fullname: c.fullname.clone(),
+                superclass_fullname: c.superclass_fullname.clone(),
+                instance_ty: c.instance_ty.clone(),
+                ivars: Rc::clone(&ivars),
+                method_sigs: c.method_sigs.clone()
+            });
+        });
+        sk_classes
+    }
+
 
     fn convert_toplevel_defs(&mut self, toplevel_defs: &Vec<ast::Definition>)
                             -> Result<HashMap<ClassFullname, Vec<SkMethod>>, Error> {

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -44,35 +44,45 @@ impl<'a> HirMaker<'a> {
 
         let sk_methods =
             hir_maker.convert_toplevel_defs(&prog.toplevel_defs)?;
-        let mut main_exprs =
+        let main_exprs =
             hir_maker.convert_exprs(&mut HirMakerContext::toplevel(), &prog.exprs)?;
-        match hir_maker {
-            HirMaker { index, constants, mut const_inits, str_literals, class_ivars } => {
-                let mut sk_classes = HashMap::new();
-                index.classes.iter().for_each(|(name, c)| {
-                    let ivars = class_ivars.get(name).expect(&format!("[BUG] ivars for class {} not found", name));
-                    // PERF: How to avoid these clone's? Use Rc?
-                    sk_classes.insert(name.clone(), SkClass {
-                        fullname: c.fullname.clone(),
-                        superclass_fullname: c.superclass_fullname.clone(),
-                        instance_ty: c.instance_ty.clone(),
-                        ivars: Rc::clone(&ivars),
-                        method_sigs: c.method_sigs.clone()
-                    });
-                });
+        Ok(hir_maker.to_hir(sk_methods, main_exprs))
+    }
 
-                const_inits.append(&mut main_exprs.exprs);
-                Ok(Hir {
-                    sk_classes,
-                    sk_methods,
-                    constants,
-                    str_literals,
-                    //str_literals,
-                    main_exprs:  HirExpressions {
-                        ty: main_exprs.ty,
-                        exprs: const_inits,
-                    }
-                })
+    /// Destructively convert self to Hir
+    fn to_hir(&mut self,
+           sk_methods: HashMap<ClassFullname, Vec<SkMethod>>,
+           mut main_exprs: HirExpressions) -> Hir {
+        let mut sk_classes = HashMap::new();
+        self.index.classes.iter().for_each(|(name, c)| {
+            let ivars = self.class_ivars.get(name).expect(&format!("[BUG] ivars for class {} not found", name));
+            // PERF: How to avoid these clone's? Use Rc?
+            sk_classes.insert(name.clone(), SkClass {
+                fullname: c.fullname.clone(),
+                superclass_fullname: c.superclass_fullname.clone(),
+                instance_ty: c.instance_ty.clone(),
+                ivars: Rc::clone(&ivars),
+                method_sigs: c.method_sigs.clone()
+            });
+        });
+
+        // Extract data from self
+        let mut constants = HashMap::new();
+        std::mem::swap(&mut constants, &mut self.constants);
+        let mut str_literals = vec![];
+        std::mem::swap(&mut str_literals, &mut self.str_literals);
+        let mut const_inits = vec![];
+        std::mem::swap(&mut const_inits, &mut self.const_inits);
+
+        const_inits.append(&mut main_exprs.exprs);
+        Hir {
+            sk_classes,
+            sk_methods,
+            constants,
+            str_literals,
+            main_exprs:  HirExpressions {
+                ty: main_exprs.ty,
+                exprs: const_inits,
             }
         }
     }

--- a/src/hir/index.rs
+++ b/src/hir/index.rs
@@ -32,14 +32,10 @@ pub struct IdxIVar {
 }
 
 impl Index {
-    pub fn new(stdlib_classes: HashMap<ClassFullname, SkClass>,
-               toplevel_defs: &Vec<ast::Definition>) -> Result<Index, Error> {
-        let mut index = Index {
+    pub fn new() -> Index {
+        Index {
             classes: HashMap::new()
-        };
-        index.index_stdlib(stdlib_classes);
-        index.index_program(toplevel_defs)?;
-        Ok(index)
+        }
     }
 
     /// Find a method from class name and first name
@@ -62,7 +58,7 @@ impl Index {
         self.classes.insert(class.fullname.clone(), class);
     }
 
-    fn index_stdlib(&mut self, stdlib_classes: HashMap<ClassFullname, SkClass>) {
+    pub fn index_stdlib(&mut self, stdlib_classes: HashMap<ClassFullname, SkClass>) {
         stdlib_classes.into_iter().for_each(|(_, c)| {
             self.add_class(IdxClass {
                 fullname: c.fullname,
@@ -73,7 +69,7 @@ impl Index {
         });
     }
 
-    fn index_program(&mut self, toplevel_defs: &Vec<ast::Definition>) -> Result<(), Error> {
+    pub fn index_program(&mut self, toplevel_defs: &Vec<ast::Definition>) -> Result<(), Error> {
         toplevel_defs.iter().try_for_each(|def| {
             match def {
                 ast::Definition::ClassDefinition { name, defs } => {

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -28,9 +28,9 @@ impl Hir {
         Ok(hir)
     }
 
-    pub fn add_classes(&mut self, sk_classes: HashMap<ClassFullname, SkClass>) {
-        self.sk_classes.extend(sk_classes)
-    }
+    //pub fn add_classes(&mut self, sk_classes: HashMap<ClassFullname, SkClass>) {
+    //    self.sk_classes.extend(sk_classes)
+    //}
 
     pub fn add_methods(&mut self, sk_methods: HashMap<ClassFullname, Vec<SkMethod>>) {
         self.sk_methods.extend(sk_methods)

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -35,7 +35,16 @@ impl Hir {
     //}
 
     pub fn add_methods(&mut self, sk_methods: HashMap<ClassFullname, Vec<SkMethod>>) {
-        self.sk_methods.extend(sk_methods)
+        for (classname, mut new_methods) in sk_methods {
+            match self.sk_methods.get_mut(&classname) {
+                Some(methods) => {
+                    methods.append(&mut new_methods);
+                },
+                None => {
+                    self.sk_methods.insert(classname, new_methods);
+                }
+            }
+        }
     }
 }
 

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -18,7 +18,9 @@ pub struct Hir {
 }
 impl Hir {
     pub fn from_ast(ast: ast::Program, stdlib: Stdlib) -> Result<Hir, crate::error::Error> {
-        let index = index::Index::new(stdlib.sk_classes, &ast.toplevel_defs)?;
+        let mut index = index::Index::new();
+        index.index_stdlib(stdlib.sk_classes);
+        index.index_program(&ast.toplevel_defs)?;
         let mut hir = hir_maker::HirMaker::convert_program(index, ast)?;
 
         // While stdlib classes are included in `index`,


### PR DESCRIPTION
The implementation is quite simple; just add corelib/*.sk before the user program.

Note that we need to merge methods because there may be two definitions of class Int, etc.