### PR TITLE
fix: Ancestor initialize

### DIFF
--- a/src/code_gen/mod.rs
+++ b/src/code_gen/mod.rs
@@ -23,7 +23,7 @@ pub struct CodeGen<'hir> {
     pub i64_type: inkwell::types::IntType,
     pub f64_type: inkwell::types::FloatType,
     pub void_type: inkwell::types::VoidType,
-    llvm_struct_types: HashMap<ClassFullname, inkwell::types::StructType>,
+    pub llvm_struct_types: HashMap<ClassFullname, inkwell::types::StructType>,
     str_literals: &'hir Vec<String>,
     /// Toplevel `self`
     the_main: Option<inkwell::values::BasicValueEnum>,

--- a/src/hir/index.rs
+++ b/src/hir/index.rs
@@ -132,7 +132,7 @@ impl Index {
                 });
                 self.add_class(IdxClass {
                     fullname: metaclass_fullname,
-                    superclass_fullname: Some(ClassFullname("Object".to_string())),
+                    superclass_fullname: Some(ClassFullname("Class".to_string())),
                     instance_ty: class_ty,
                     ivars: Rc::new(HashMap::new()),
                     method_sigs: class_methods,

--- a/src/names.rs
+++ b/src/names.rs
@@ -70,6 +70,14 @@ pub struct MethodFullname {
     pub first_name: MethodFirstname,
 }
 
+pub fn method_fullname(class_name: &ClassFullname,
+                       first_name: &str) -> MethodFullname {
+    MethodFullname {
+        full_name: class_name.0.clone() + "#" + first_name,
+        first_name: MethodFirstname(first_name.to_string()),
+    }
+}
+
 impl std::fmt::Display for MethodFullname {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.full_name)


### PR DESCRIPTION
This was failing

```
class A; end
puts A.name
```