### PR TITLE
Infer more specific type of array

### DIFF
--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -434,7 +434,6 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         self.builder.build_conditional_branch(istrue, then_block, else_block);
     }
                              
-
     fn gen_bitcast(&self,
                    ctx: &mut CodeGenContext<'run>,
                    expr: &HirExpression,

--- a/src/hir/class_dict.rs
+++ b/src/hir/class_dict.rs
@@ -104,6 +104,22 @@ impl ClassDict {
         })
     }
 
+    /// Return supertype of `ty`
+    pub fn supertype_of(&self, ty: &TermTy) -> Option<TermTy> {
+        ty.supertype(self)
+    }
+
+    /// Return ancestor types of `ty`, including itself.
+    pub fn ancestor_types(&self, ty: &TermTy) -> Vec<TermTy> {
+        let mut v = vec![];
+        let mut t = Some(ty.clone());
+        while t.is_some() {
+            v.push(t.unwrap());
+            t = self.supertype_of(&v.last().unwrap())
+        }
+        v
+     }
+
     pub fn find_ivar(&self,
                      classname: &ClassFullname,
                      ivar_name: &str) -> Option<&SkIVar> {

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -381,7 +381,13 @@ impl HirMaker {
             self.convert_expr(ctx, expr)
         ).collect::<Result<Vec<_>, _>>()?;
 
-        Ok(Hir::array_literal(hir_exprs))
+        // TODO #102: Support empty array literal
+        let mut ty = hir_exprs[0].ty.clone();
+        for expr in &hir_exprs {
+            ty = self.nearest_common_ancestor_type(&ty, &expr.ty)
+        }
+        
+        Ok(Hir::array_literal(hir_exprs, ty::spe("Array", vec![ty.clone()])))
     }
 
     fn convert_self_expr(&self, ctx: &HirMakerContext) -> Result<HirExpression, Error> {

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -398,4 +398,16 @@ impl HirMaker {
         self.str_literals.push(content.to_string());
         idx
     }
+
+    /// Return the nearest common ancestor of the classes
+    fn nearest_common_ancestor_type(&self, ty1: &TermTy, ty2: &TermTy) -> TermTy {
+        let ancestors1 = self.class_dict.ancestor_types(ty1);
+        let ancestors2 = self.class_dict.ancestor_types(ty2);
+        for t2 in ancestors2 {
+            if let Some(eq) = ancestors1.iter().find(|t1| t1.equals_to(&t2)) {
+                return eq.clone()
+            }
+        }
+        panic!("[BUG] nearest_common_ancestor_type not found");
+    }
 }

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -350,10 +350,9 @@ impl Hir {
         }
     }
 
-    pub fn array_literal(exprs: Vec<HirExpression>) -> HirExpression {
+    pub fn array_literal(exprs: Vec<HirExpression>, ty: TermTy) -> HirExpression {
         HirExpression {
-            // TODO: infer more specific type from the elements
-            ty: ty::spe("Array", vec![ty::raw("Object")]),
+            ty,
             node: HirExpressionBase::HirArrayLiteral { exprs }
         }
     }

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -1,7 +1,7 @@
 mod accessors;
 mod hir_maker;
 mod hir_maker_context;
-mod class_dict;
+pub mod class_dict;
 mod method_dict;
 mod sk_class;
 mod convert_exprs;

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -15,6 +15,7 @@
 ///
 use crate::names::*;
 use crate::ty;
+use crate::hir::class_dict::ClassDict;
 
 // Types for a term (types of Shiika values)
 #[derive(Debug, PartialEq, Clone)]
@@ -78,6 +79,27 @@ impl TermTy {
     /// Return true if two types are identical
     pub fn equals_to(&self, other: &TermTy) -> bool {
         self == other
+    }
+
+    /// Return the supertype of self
+    pub fn supertype(&self, class_dict: &ClassDict) -> Option<TermTy> {
+        match &self.body {
+            TyRaw => {
+                class_dict.get_superclass(&self.fullname).map(|scls| {
+                    ty::raw(&scls.fullname.0)
+                })
+            },
+            TyMeta { base_fullname} => {
+                match class_dict.get_superclass(&class_fullname(base_fullname)) {
+                    Some(scls) => {
+                        Some(ty::meta(&scls.fullname.0))
+                    },
+                    None => Some(ty::class())  // Meta:Object < Class
+                }
+            },
+            TyClass => Some(ty::raw("Object")),
+            _ => panic!("TODO"),
+        }
     }
 }
 


### PR DESCRIPTION
`[1,2]` is now inferred as `Array<Int>`, not `Array<Object>`.

refs #101