### PR TITLE
fix(runner): check clang status code

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -99,8 +99,9 @@ fn run_<P: AsRef<Path>>(
     cmd.arg("-o");
     cmd.arg(out_path.clone());
     cmd.arg(asm_path.clone());
-    cmd.output()
-        .map_err(|e| runner_error("failed to run clang", e))?;
+    if !cmd.status()?.success() {
+        return Err(Box::new(plain_runner_error("failed to run clang")));
+    }
 
     //fs::remove_file(bc_path)?;
     fs::remove_file(asm_path).map_err(|e| runner_error("failed to remove .s", e))?;


### PR DESCRIPTION
Since `Command#output()?` only checks whether the command process is run, but not check the process's status code.

I found this when the clang build is failed because I don't have libgc-dev installed on my machine, but the codes continues to try to run the build result but the result binary is not generated.