### PR TITLE
fix(runner): binary path to run

### DIFF
--- a/src/runner.rs
+++ b/src/runner.rs
@@ -106,7 +106,7 @@ fn run_<P: AsRef<Path>>(
     //fs::remove_file(bc_path)?;
     fs::remove_file(asm_path).map_err(|e| runner_error("failed to remove .s", e))?;
 
-    let mut cmd = Command::new(out_path);
+    let mut cmd = Command::new(format!("./{}", out_path.to_string()));
     if capture_out {
         let output = cmd
             .output()


### PR DESCRIPTION
Currently `shiika run` is broken due to the run command tring to using `out_path` without `./` prefix, and this leads to let the OS tries to find the binary from PATH.