### PR TITLE
docs: update markdown format for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,18 @@ Shiika has lots in common with Crystal. However:
 
 ## Example
 
-        class A
-          def fib(n: Int) -> Int
-            if n < 3
-              1
-            else
-              fib(n-1) + fib(n-2)
-            end
-          end
-        end
-        A.new.fib(34)
+```crystal
+class A
+  def fib(n: Int) -> Int
+    if n < 3
+      1
+    else
+      fib(n-1) + fib(n-2)
+    end
+  end
+end
+A.new.fib(34)
+```
 
 See `examples/*.sk` for more.
 


### PR DESCRIPTION
Seems current there were some unnecessary indents on the code block on README.md, this PR is fixing this. And I thought we can using the crystal's syntax highlight for now since their's grammar is similar now.

You can take a preview on the render result here: https://github.com/aisk/shiika/blob/ed798859ef3a7613619fd0c1b3c067c3ad6a7b6c/README.md