### PR TITLE
Evaluate `A<B>` to a specific class

### DIFF
--- a/builtin/array.sk
+++ b/builtin/array.sk
@@ -51,3 +51,6 @@ class Array<T>
     @n_items
   end
 end
+
+# Create `Meta:Array` by this ConstRef for array literals
+Array

--- a/builtin/array.sk
+++ b/builtin/array.sk
@@ -1,11 +1,12 @@
 # TODO: Move to Array::
 BYTES_OF_PTR = 8  # Assuming 64bit env
+INITIAL_CAPA = 10
 
 class Array<T>
-  def initialize(capa: Int)
-    var @capa = capa
+  def initialize
+    var @capa = INITIAL_CAPA
     var @n_items = 0
-    var @items = Shiika::Internal::Memory.gc_malloc(BYTES_OF_PTR * capa)
+    var @items = Shiika::Internal::Memory.gc_malloc(BYTES_OF_PTR * INITIAL_CAPA)
   end
 
 # TODO #147: Generic methods

--- a/builtin/array.sk
+++ b/builtin/array.sk
@@ -52,5 +52,5 @@ class Array<T>
   end
 end
 
-# Create `Meta:Array` by this ConstRef for array literals
+# Create `Meta:Array` by this ConstRef for array literals (#178)
 Array

--- a/builtin/lambda.sk
+++ b/builtin/lambda.sk
@@ -97,3 +97,6 @@ class Fn9<S1, S2, S3, S4, S5, S6, S7, S8, S9, T>
     @captures = captures
   end
 end
+
+# Create `::FnX` by these ConstRef's for lambda exprs (#178)
+Fn0; Fn1; Fn2; Fn3; Fn4; Fn5; Fn6; Fn7; Fn8; Fn9

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -111,7 +111,7 @@ pub enum AstExpressionBody {
     // Local variable reference or method call with implicit receiver(self)
     BareName(String),
     IVarRef(String),
-    ConstRef(AstConstName),
+    ConstRef(ConstName),
     PseudoVariable(Token),
     ArrayLiteral(Vec<AstExpression>),
     FloatLiteral {
@@ -123,25 +123,6 @@ pub enum AstExpressionBody {
     StringLiteral {
         content: String,
     },
-}
-
-#[derive(Debug, PartialEq, Clone)]
-pub struct AstConstName {
-    pub names: Vec<String>,
-    pub args: Vec<AstConstName>,
-}
-
-impl AstConstName {
-    pub fn string(&self) -> String {
-        let mut s = self.names.join("::");
-        if !self.args.is_empty() {
-            s += "<";
-            let v = self.args.iter().map(|x| x.string()).collect::<Vec<_>>();
-            s += &v.join(",");
-            s += ">";
-        }
-        s
-    }
 }
 
 impl Definition {
@@ -296,7 +277,7 @@ pub fn ivar_ref(name: String) -> AstExpression {
     primary_expression(AstExpressionBody::IVarRef(name))
 }
 
-pub fn const_ref(name: AstConstName) -> AstExpression {
+pub fn const_ref(name: ConstName) -> AstExpression {
     primary_expression(AstExpressionBody::ConstRef(name))
 }
 

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -529,7 +529,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         let ary = self.gen_llvm_func_call(
             "Meta:Array#new",
             self.gen_const_ref(&const_name(vec!["Array".to_string()])),
-            vec![self.gen_decimal_literal(exprs.len() as i32)],
+            vec![],
         )?;
         for expr in exprs {
             let item = self.gen_expr(ctx, expr)?;

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -478,7 +478,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         let ary = self.gen_llvm_func_call(
             "Meta:Array#new",
             self.gen_const_ref(&const_name(vec!["Array".to_string()])),
-            vec![self.gen_decimal_literal(captures.len() as i32)],
+            vec![],
         )?;
         for cap in captures {
             let item = match cap {

--- a/src/code_gen/mod.rs
+++ b/src/code_gen/mod.rs
@@ -236,26 +236,24 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
 
     /// Create llvm struct types for Shiika objects
     fn gen_class_structs(&mut self, classes: &HashMap<ClassFullname, SkClass>) {
-        // 1. Create struct type for each class
+        // Create all the struct types in advance
         for name in classes.keys() {
             self.llvm_struct_types
                 .insert(name.clone(), self.context.opaque_struct_type(&name.0));
         }
 
-        // 2. Set ivars
+        // Set fields for ivars
         let vt = self.llvm_vtable_ref_type().into();
-        for (name, sk_class) in classes {
-            let struct_type = self.llvm_struct_types.get(&name).unwrap();
-            if name.0 == "Int" {
-                struct_type.set_body(&[vt, self.i32_type.into()], false);
-            } else if name.0 == "Float" {
-                struct_type.set_body(&[vt, self.f64_type.into()], false);
-            } else if name.0 == "Bool" {
-                struct_type.set_body(&[vt, self.i1_type.into()], false);
-            } else if name.0 == "Shiika::Internal::Ptr" {
-                struct_type.set_body(&[vt, self.i8ptr_type.into()], false);
-            } else {
-                struct_type.set_body(&self.llvm_field_types(&sk_class.ivars), false);
+        for (name, class) in classes {
+            let struct_type = self.llvm_struct_types.get(name).unwrap();
+            match name.0.as_str() {
+                "Int" => { struct_type.set_body(&[vt, self.i32_type.into()], false); }
+                "Float" => { struct_type.set_body(&[vt, self.f64_type.into()], false); }
+                "Bool" => { struct_type.set_body(&[vt, self.i1_type.into()], false); }
+                "Shiika::Internal::Ptr" => { struct_type.set_body(&[vt, self.i8ptr_type.into()], false); }
+                _ => {
+                    struct_type.set_body(&self.llvm_field_types(&class.ivars), false);
+                }
             }
         }
     }
@@ -295,6 +293,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
         })
     }
 
+    /// Generate llvm global that holds Shiika constants
     fn gen_constant_ptrs(&self, constants: &HashMap<ConstFullname, TermTy>) {
         for (fullname, ty) in constants {
             let name = &fullname.0;

--- a/src/hir/class_dict/indexing.rs
+++ b/src/hir/class_dict/indexing.rs
@@ -28,7 +28,7 @@ impl ClassDict {
     }
 
     /// Register a class
-    fn add_class(&mut self, class: SkClass) {
+    pub fn add_class(&mut self, class: SkClass) {
         self.sk_classes.insert(class.fullname.clone(), class);
     }
 
@@ -90,7 +90,7 @@ impl ClassDict {
         let new_sig = signature::signature_of_new(
             &metaclass_fullname,
             self.initializer_params(&super_name.instance_ty(), &defs),
-            &instance_ty,
+            &ty::return_type_of_new(fullname, typarams),
         );
 
         for def in defs {

--- a/src/hir/class_dict/indexing.rs
+++ b/src/hir/class_dict/indexing.rs
@@ -133,6 +133,7 @@ impl ClassDict {
                 }
             }
             None => {
+                let ty_params = typarams.iter().map(|s| TyParam { name: s.to_string() }).collect::<Vec<_>>();
                 // Add `.new` to the metaclass
                 class_methods.insert(new_sig.fullname.first_name.clone(), new_sig);
                 if !self.class_exists(&super_name.0) {
@@ -143,7 +144,7 @@ impl ClassDict {
                 }
                 self.add_class(SkClass {
                     fullname: fullname.clone(),
-                    typarams: vec![],
+                    typarams: ty_params.clone(),
                     superclass_fullname: Some(super_name.clone()),
                     instance_ty,
                     ivars: HashMap::new(),
@@ -152,7 +153,7 @@ impl ClassDict {
                 });
                 self.add_class(SkClass {
                     fullname: metaclass_fullname,
-                    typarams: vec![],
+                    typarams: ty_params,
                     superclass_fullname: Some(class_fullname("Class")),
                     instance_ty: class_ty,
                     ivars: HashMap::new(),

--- a/src/hir/class_dict/query.rs
+++ b/src/hir/class_dict/query.rs
@@ -24,19 +24,19 @@ impl ClassDict {
         class: &TermTy,
         method_name: &MethodFirstname,
     ) -> Result<(MethodSignature, ClassFullname), Error> {
-        if let TyBody::TySpe {
-            base_name,
-            type_args,
-        } = &class.body
-        {
-            let base_cls = &self
-                .find_class(&class_fullname(base_name))
-                .expect("[BUG] base_cls not found")
-                .instance_ty;
-            let (base_sig, found_cls) = self.lookup_method_(base_cls, base_cls, method_name)?;
-            Ok((base_sig.specialize(&type_args), found_cls))
-        } else {
-            self.lookup_method_(class, class, method_name)
+        match &class.body {
+            TyBody::TyRaw | TyBody::TyMeta { .. } | TyBody::TyClass => {
+                self.lookup_method_(class, class, method_name)
+            }
+            TyBody::TySpe { type_args, .. } | TyBody::TySpeMeta { type_args, .. } => {
+                let base_cls = &self
+                    .find_class(&class.base_class_name())
+                    .expect("[BUG] base_cls not found")
+                    .instance_ty;
+                let (base_sig, found_cls) = self.lookup_method_(base_cls, base_cls, method_name)?;
+                Ok((base_sig.specialize(&type_args), found_cls))
+            }
+            _ => todo!()
         }
     }
 

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -105,7 +105,7 @@ impl HirMaker {
 
             AstExpressionBody::IVarRef(names) => self.convert_ivar_ref(names),
 
-            AstExpressionBody::ConstRef(names) => self.convert_const_ref(names),
+            AstExpressionBody::ConstRef(name) => self.convert_const_ref(name),
 
             AstExpressionBody::PseudoVariable(token) => self.convert_pseudo_variable(token),
 
@@ -559,13 +559,13 @@ impl HirMaker {
     }
 
     /// Resolve constant name
-    fn convert_const_ref(&self, names: &[String]) -> Result<HirExpression, Error> {
+    fn convert_const_ref(&self, name: &AstConstName) -> Result<HirExpression, Error> {
         // TODO: Resolve using ctx
-        let fullname = ConstFullname("::".to_string() + &names.join("::"));
+        let fullname = ConstFullname("::".to_string() + &name.string());
         match self.constants.get(&fullname) {
             Some(ty) => Ok(Hir::const_ref(ty.clone(), fullname)),
             None => {
-                let c = class_fullname(&names.join("::"));
+                let c = class_fullname(&name.string());
                 if self.class_dict.class_exists(&c.0) {
                     Ok(Hir::const_ref(c.class_ty(), fullname))
                 } else {

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -559,15 +559,15 @@ impl HirMaker {
     }
 
     /// Resolve constant name
-    fn convert_const_ref(&self, name: &AstConstName) -> Result<HirExpression, Error> {
+    fn convert_const_ref(&self, name: &ConstName) -> Result<HirExpression, Error> {
         // TODO: Resolve using ctx
-        let fullname = ConstFullname("::".to_string() + &name.string());
-        match self.constants.get(&fullname) {
-            Some(ty) => Ok(Hir::const_ref(ty.clone(), fullname)),
+        let fullname = name.fullname();
+        match self.constants.get(&const_fullname(&fullname)) {
+            Some(ty) => Ok(Hir::const_ref(ty.clone(), name.clone())),
             None => {
                 let c = class_fullname(&name.string());
                 if self.class_dict.class_exists(&c.0) {
-                    Ok(Hir::const_ref(c.class_ty(), fullname))
+                    Ok(Hir::const_ref(c.class_ty(), name.clone()))
                 } else {
                     Err(error::program_error(&format!(
                         "constant `{:?}' was not found",

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -330,15 +330,14 @@ impl HirMaker {
             // Implicit self
             _ => self.convert_self_expr()?,
         };
-        // TODO: arg types must match with method signature
         let arg_hirs = arg_exprs
             .iter()
             .map(|arg_expr| self.convert_expr(arg_expr))
             .collect::<Result<Vec<_>, _>>()?;
-
         self.make_method_call(receiver_hir, &method_name, arg_hirs)
     }
 
+    /// Resolve the method and create HirMethodCall
     fn make_method_call(
         &self,
         receiver_hir: HirExpression,
@@ -559,23 +558,43 @@ impl HirMaker {
     }
 
     /// Resolve constant name
-    fn convert_const_ref(&self, name: &ConstName) -> Result<HirExpression, Error> {
+    fn convert_const_ref(&mut self, name: &ConstName) -> Result<HirExpression, Error> {
         // TODO: Resolve using ctx
-        let fullname = name.fullname();
-        match self.constants.get(&const_fullname(&fullname)) {
-            Some(ty) => Ok(Hir::const_ref(ty.clone(), name.clone())),
-            None => {
-                let c = class_fullname(&name.string());
-                if self.class_dict.class_exists(&c.0) {
-                    Ok(Hir::const_ref(c.class_ty(), name.clone()))
-                } else {
-                    Err(error::program_error(&format!(
-                        "constant `{:?}' was not found",
-                        fullname
-                    )))
-                }
-            }
+        if let Some(ty) = self.constants.get(&name.to_const_fullname()) {
+            return Ok(Hir::const_ref(ty.clone(), name.clone()))
         }
+        // Check if it refers to a class
+        if self.class_dict.class_exists(&name.names.join("::")) {
+            self._create_class_const(name);
+            return Ok(Hir::const_ref(name.class_ty(), name.clone()))
+        }
+        Err(error::program_error(&format!("constant `{:?}' was not found", name.fullname())))
+    }
+
+    /// Register constant of a class object
+    fn _create_class_const(&mut self, name: &ConstName) {
+        let idx = self.register_string_literal(&name.string());
+        let expr = Hir::class_literal(name, idx);
+        self.register_const_full(name.to_const_fullname(), expr);
+
+        // If the const is `A<B>`, also create its type `Meta:A<B>`
+        if name.args.len() > 0 {
+            self._create_specialized_meta_class(name);
+        }
+    }
+
+    /// Create `Meta:A<B>` when there is a const `A<B>`
+    fn _create_specialized_meta_class(&mut self, name: &ConstName) {
+        let mut ivars = HashMap::new();
+        ivars.insert("name".to_string(), SkIVar {
+            idx: 0,
+            name: "name".to_string(),
+            ty: ty::raw("String"),
+            readonly: true,
+        });
+        let tyargs = name.args.iter().map(|arg| arg.to_ty()).collect::<Vec<_>>();
+        let cls = self.class_dict.find_class(&class_fullname("Meta:".to_string()+&name.names.join("::"))).unwrap().specialized_meta(&tyargs);
+        self.class_dict.add_class(cls);
     }
 
     fn convert_pseudo_variable(&self, token: &Token) -> Result<HirExpression, Error> {

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -96,7 +96,7 @@ impl HirExpressions {
     // Destructively convert Vec<HirExpression> into HirExpressions
     pub fn new(mut exprs: Vec<HirExpression>) -> HirExpressions {
         if exprs.is_empty() {
-            exprs.push(Hir::const_ref(ty::raw("Void"), const_fullname("::Void")))
+            exprs.push(Hir::const_ref(ty::raw("Void"), const_name(vec!["Void".to_string()])))
         }
 
         let last_expr = exprs.last().unwrap();
@@ -165,7 +165,7 @@ pub enum HirExpressionBase {
         idx: usize,
     },
     HirConstRef {
-        fullname: ConstFullname,
+        name: ConstName,
     },
     HirLambdaExpr {
         name: String,
@@ -374,10 +374,10 @@ impl Hir {
         }
     }
 
-    pub fn const_ref(ty: TermTy, fullname: ConstFullname) -> HirExpression {
+    pub fn const_ref(ty: TermTy, name: ConstName) -> HirExpression {
         HirExpression {
             ty,
-            node: HirExpressionBase::HirConstRef { fullname },
+            node: HirExpressionBase::HirConstRef { name },
         }
     }
 

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -457,11 +457,11 @@ impl Hir {
         }
     }
 
-    pub fn class_literal(fullname: ClassFullname, str_literal_idx: usize) -> HirExpression {
+    pub fn class_literal(name: &ConstName, str_literal_idx: usize) -> HirExpression {
         HirExpression {
-            ty: ty::meta(&fullname.0),
+            ty: name.class_ty(),
             node: HirExpressionBase::HirClassLiteral {
-                fullname,
+                fullname: name.to_class_fullname(),
                 str_literal_idx,
             },
         }

--- a/src/hir/signature.rs
+++ b/src/hir/signature.rs
@@ -46,6 +46,7 @@ pub fn convert_params(params: &[ast::Param], typarams: &[String]) -> Vec<MethodP
         .collect()
 }
 
+/// Create a signature of a `new` method
 pub fn signature_of_new(
     metaclass_fullname: &ClassFullname,
     initialize_params: Vec<MethodParam>,

--- a/src/hir/sk_class.rs
+++ b/src/hir/sk_class.rs
@@ -1,4 +1,5 @@
 use crate::names::*;
+use crate::ty;
 use crate::ty::*;
 use std::collections::HashMap;
 
@@ -30,5 +31,29 @@ impl SkClass {
         // Sort by first name
         v.sort_unstable_by(|a, b| a.first_name.0.cmp(&b.first_name.0));
         v
+    }
+
+    /// Create a specialized metaclass of a generic metaclass
+    /// eg. create `Meta:Array<Int>` from `Meta:Array`
+    pub fn specialized_meta(&self, tyargs: &[TermTy]) -> SkClass {
+        // `self` must be a generic metaclass.
+        debug_assert!(self.typarams.len() > 0);
+        let base_name =
+            if let TyBody::TyMeta { base_fullname } = &self.instance_ty.body { base_fullname }
+            else { panic!("SkClass::specialize: not TyMeta") };
+        let instance_ty = ty::spe_meta(&base_name, tyargs.to_vec());
+        let method_sigs = self.method_sigs.iter().map(|(name, sig)| {
+            (name.clone(), sig.specialize(tyargs))
+        }).collect(); //::<Vec<_>>;
+
+        SkClass {
+            fullname: instance_ty.fullname.clone(),
+            typarams: vec![],
+            superclass_fullname: self.superclass_fullname.clone(),
+            instance_ty,
+            ivars: self.ivars.clone(),
+            method_sigs,
+            const_is_obj: self.const_is_obj,
+        }
     }
 }

--- a/src/names.rs
+++ b/src/names.rs
@@ -126,3 +126,30 @@ impl std::fmt::Display for ConstFullname {
 pub fn const_fullname(s: &str) -> ConstFullname {
     ConstFullname(s.to_string())
 }
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct ConstName {
+    pub names: Vec<String>,
+    pub args: Vec<ConstName>,
+}
+
+impl ConstName {
+    pub fn fullname(&self) -> String {
+        "::".to_string() + &self.string()
+    }
+
+    pub fn string(&self) -> String {
+        let mut s = self.names.join("::");
+        if !self.args.is_empty() {
+            s += "<";
+            let v = self.args.iter().map(|x| x.string()).collect::<Vec<_>>();
+            s += &v.join(",");
+            s += ">";
+        }
+        s
+    }
+}
+
+pub fn const_name(names: Vec<String>) -> ConstName {
+    ConstName { names, args: vec![] }
+}

--- a/src/names.rs
+++ b/src/names.rs
@@ -134,10 +134,22 @@ pub struct ConstName {
 }
 
 impl ConstName {
+    /// Make ConstFullname from self
+    pub fn to_const_fullname(&self) -> ConstFullname {
+        const_fullname(&self.fullname())
+    }
+
+    /// Make ClassFullname from self
+    pub fn to_class_fullname(&self) -> ClassFullname {
+        class_fullname(&self.string())
+    }
+
+    /// Return const name as String
     pub fn fullname(&self) -> String {
         "::".to_string() + &self.string()
     }
 
+    /// Return class name as String
     pub fn string(&self) -> String {
         let mut s = self.names.join("::");
         if !self.args.is_empty() {
@@ -147,6 +159,23 @@ impl ConstName {
             s += ">";
         }
         s
+    }
+
+    /// Make TermTy form self
+    pub fn to_ty(&self) -> TermTy {
+        if self.args.is_empty() {
+            ty::raw(&self.names.join("::"))
+        } else {
+            let type_args = self.args.iter().map(|n| n.to_ty()).collect();
+            ty::spe(&self.names.join("::"), type_args)
+        }
+    }
+
+    /// Make TermTy of the class
+    /// eg. for `::Array<Int>`, returns `TermTy(Meta:Array<Int>)`, which is
+    /// the type of the constant
+    pub fn class_ty(&self) -> TermTy {
+        self.to_ty().meta_ty()
     }
 }
 

--- a/src/parser/expression_parser.rs
+++ b/src/parser/expression_parser.rs
@@ -1,4 +1,5 @@
 use crate::parser::base::*;
+use crate::names::ConstName;
 use std::collections::HashMap;
 
 impl<'a> Parser<'a> {
@@ -688,8 +689,8 @@ impl<'a> Parser<'a> {
         Ok(ast::const_ref(name))
     }
 
-    /// Main routine of parse_const_ref (returns AstConstName)
-    fn _parse_const_ref(&mut self, s: String, recursing: bool) -> Result<AstConstName, Error> {
+    /// Main routine of parse_const_ref (returns ConstName)
+    fn _parse_const_ref(&mut self, s: String, recursing: bool) -> Result<ConstName, Error> {
         self.lv += 1;
         self.debug_log("_parse_const_ref");
         let mut names = vec![s];
@@ -746,7 +747,7 @@ impl<'a> Parser<'a> {
             }
         }
         self.lv -= 1;
-        Ok(AstConstName { names, args })
+        Ok(ConstName { names, args })
     }
 
     fn parse_lambda(&mut self) -> Result<AstExpression, Error> {

--- a/src/parser/expression_parser.rs
+++ b/src/parser/expression_parser.rs
@@ -632,6 +632,7 @@ impl<'a> Parser<'a> {
             }
             Token::UpperWord(s) => {
                 let name = s.to_string();
+                self.consume_token();
                 self.parse_const_ref(name)
             }
             Token::KwFn => self.parse_lambda(),
@@ -680,21 +681,72 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_const_ref(&mut self, s: String) -> Result<AstExpression, Error> {
+        self.lv += 1;
+        self.debug_log("parse_const_ref");
+        let name = self._parse_const_ref(s, false)?;
+        self.lv -= 1;
+        Ok(ast::const_ref(name))
+    }
+
+    /// Main routine of parse_const_ref (returns AstConstName)
+    fn _parse_const_ref(&mut self, s: String, recursing: bool) -> Result<AstConstName, Error> {
+        self.lv += 1;
+        self.debug_log("_parse_const_ref");
         let mut names = vec![s];
-        self.consume_token();
-        // Parse `A::B`
-        while self.current_token_is(Token::ColonColon) {
-            self.consume_token();
+        let mut lessthan_seen = false;
+        let mut args = vec![];
+        loop {
             match self.current_token() {
+                Token::ColonColon => { // `A::B`
+                    if lessthan_seen {
+                        return Err(parse_error!(self, "unexpected `::'"));
+                    }
+                    self.consume_token();
+                }
+                Token::LessThan => { // `A<B>`
+                    lessthan_seen = true;
+                    self.consume_token();
+                }
+                Token::GreaterThan => { // `A<B>`
+                    if recursing {
+                        break;
+                    }
+                    if !lessthan_seen {
+                        return Err(parse_error!(self, "unexpected `>'"));
+                    }
+                    self.consume_token();
+                    break;
+                }
+                Token::Comma => { // `A<B, C>`
+                    if !lessthan_seen {
+                        return Err(parse_error!(self, "unexpected `,'"));
+                    }
+                    self.consume_token();
+                    self.skip_wsn();
+                }
                 Token::UpperWord(s) => {
                     let name = s.to_string();
                     self.consume_token();
-                    names.push(name);
+                    if lessthan_seen {
+                        args.push(self._parse_const_ref(name, true)?);
+                    } else {
+                        names.push(name);
+                    }
                 }
-                token => return Err(parse_error!(self, "unexpected token: {:?}", token)),
+                token => {
+                    if recursing {
+                        break;
+                    }
+                    if lessthan_seen {
+                        return Err(parse_error!(self, "unexpected token: {:?}", token));
+                    } else {
+                        break;
+                    }
+                }
             }
         }
-        Ok(ast::const_ref(names))
+        self.lv -= 1;
+        Ok(AstConstName { names, args })
     }
 
     fn parse_lambda(&mut self) -> Result<AstExpression, Error> {

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -128,9 +128,14 @@ impl TermTy {
     }
 
     /// Apply type argments into type parameters
-    pub fn substitute(&self, type_args: &[TermTy]) -> TermTy {
+    pub fn substitute(&self, tyargs: &[TermTy]) -> TermTy {
         match &self.body {
-            TyParamRef { idx, .. } => type_args[*idx].clone(),
+            TyParamRef { idx, .. } => tyargs[*idx].clone(),
+            TySpe { base_name, type_args } => {
+                let args = type_args.iter().map(|t| t.substitute(tyargs)).collect();
+                ty::spe(base_name, args)
+            }
+            TySpeMeta { .. } => todo!(),
             _ => self.clone(),
         }
     }

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -83,10 +83,15 @@ impl TermTy {
     }
 
     pub fn meta_ty(&self) -> TermTy {
-        match self.body {
+        match &self.body {
             TyRaw => ty::meta(&self.fullname.0),
             TyMeta { .. } => ty::class(),
             TyClass => ty::class(),
+            TyGenMeta { .. } => ty::class(),
+            TySpe { base_name, type_args } => {
+                ty::spe_meta(&base_name, type_args.clone())
+            }
+            TySpeMeta { .. } => ty::class(),
             _ => panic!("TODO"),
         }
     }

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -169,6 +169,7 @@ impl TermTy {
 }
 
 pub fn raw(fullname: &str) -> TermTy {
+    debug_assert!(!fullname.contains('<'), fullname.to_string());
     TermTy {
         fullname: class_fullname(fullname),
         body: TyRaw,
@@ -176,6 +177,7 @@ pub fn raw(fullname: &str) -> TermTy {
 }
 
 pub fn meta(base_fullname: &str) -> TermTy {
+    debug_assert!(!base_fullname.contains('<'), base_fullname.to_string());
     TermTy {
         fullname: metaclass_fullname(base_fullname),
         body: TyMeta {

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -240,6 +240,24 @@ pub fn spe_meta(base_name: &str, type_args: Vec<TermTy>) -> TermTy {
     }
 }
 
+/// Create the type of return value of `.new` method of the class
+pub fn return_type_of_new(classname: &ClassFullname, typarams: &[String]) -> TermTy {
+    if typarams.is_empty() {
+        ty::raw(&classname.0)
+    } else {
+        let args = typarams.iter().enumerate().map(|(i, s)| {
+            TermTy {
+                fullname: class_fullname(s),
+                body: TyParamRef {
+                    name: s.to_string(),
+                    idx: i,
+                }
+            }
+        }).collect::<Vec<_>>();
+        ty::spe(&classname.0, args)
+    }
+}
+
 /// Shortcut for Array<T>
 pub fn ary(type_arg: TermTy) -> TermTy {
     spe("Array", vec![type_arg])

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -233,7 +233,7 @@ pub fn spe_meta(base_name: &str, type_args: Vec<TermTy>) -> TermTy {
         .collect::<Vec<_>>();
     TermTy {
         fullname: class_fullname(&format!("Meta:{}<{}>", &base_name, &tyarg_names.join(","))),
-        body: TySpe {
+        body: TySpeMeta {
             base_name: base_name.to_string(),
             type_args,
         },

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -96,6 +96,15 @@ impl TermTy {
         }
     }
 
+    /// Return "A" for "A<B>", "Meta:A" for "Meta:A<B>"
+    pub fn base_class_name(&self) -> ClassFullname {
+        match &self.body {
+            TySpe { base_name, .. } => class_fullname(base_name),
+            TySpeMeta { base_name, .. } => class_fullname("Meta:".to_string() + base_name),
+            _ => panic!("unexpected"),
+        }
+    }
+
     /// Return true if `self` conforms to `other` i.e.
     /// an object of the type `self` is included in the set of objects represented by the type `other`
     pub fn conforms_to(&self, other: &TermTy, class_dict: &ClassDict) -> bool {

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -32,7 +32,8 @@ impl std::fmt::Display for TermTy {
 
 impl std::fmt::Debug for TermTy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "TermTy(\"{}\")", self.fullname)
+        write!(f, "TermTy({})", self.fullname)
+        //write!(f, "TermTy({:?})", self.body)
     }
 }
 

--- a/tests/expression_parser_test.rs
+++ b/tests/expression_parser_test.rs
@@ -1,4 +1,5 @@
 use shiika::ast;
+use shiika::names;
 use shiika::parser::Parser;
 
 fn parse_expr(src: &str) -> Result<ast::AstExpression, shiika::error::Error> {
@@ -38,7 +39,7 @@ fn test_const_assign() {
     assert_eq!(
         result.unwrap(),
         ast::assignment(
-            ast::const_ref(vec!["X".to_string()]),
+            ast::const_ref(names::const_name(vec!["X".to_string()])),
             ast::decimal_literal(1)
         )
     )

--- a/tests/sk/array.sk
+++ b/tests/sk/array.sk
@@ -1,6 +1,8 @@
 a = [123]
-if a.first != 123
-  puts "ng"
-end
+unless a.first == 123; puts "ng #first"; end
+
+b = Array<Int>.new
+b.push(123)
+unless b.nth(0) == 123; puts "ng Array<Int>.new"; end
 
 puts "ok"


### PR DESCRIPTION
fix #102

- [x] Parse `A<B>`
- [x] Collect all occurrences of `?<?>`
- [x] Create class objects and define constants for them
- [x] Refactor: move AstConstName to names.rs