### PR TITLE
fix: Proper handilng of Void/Never if-clause

### DIFF
--- a/src/code_gen/lambda.rs
+++ b/src/code_gen/lambda.rs
@@ -51,9 +51,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
             } => {
                 self.gen_lambda_funcs_in_expr(cond_expr)?;
                 self.gen_lambda_funcs_in_exprs(&then_exprs.exprs)?;
-                if else_exprs.is_some() {
-                    self.gen_lambda_funcs_in_exprs(&else_exprs.as_ref().as_ref().unwrap().exprs)?;
-                }
+                self.gen_lambda_funcs_in_exprs(&else_exprs.exprs)?;
             }
             HirWhileExpression {
                 cond_expr,

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -93,20 +93,29 @@ pub struct HirExpressions {
 }
 
 impl HirExpressions {
-    // Destructively convert Vec<HirExpression> into HirExpressions
+    /// Destructively convert Vec<HirExpression> into HirExpressions
     pub fn new(mut exprs: Vec<HirExpression>) -> HirExpressions {
         if exprs.is_empty() {
-            exprs.push(Hir::const_ref(
-                ty::raw("Void"),
-                const_name(vec!["Void".to_string()]),
-            ))
+            exprs.push(void_const_ref());
         }
-
         let last_expr = exprs.last().unwrap();
         let ty = last_expr.ty.clone();
 
         HirExpressions { ty, exprs }
     }
+
+    /// Change the type of `self` to `Void`
+    pub fn voidify(&mut self) {
+        self.exprs.push(void_const_ref());
+        self.ty = ty::raw("Void");
+    }
+}
+/// Make a HirExpression to refer `::Void`
+fn void_const_ref() -> HirExpression {
+    Hir::const_ref(
+        ty::raw("Void"),
+        const_name(vec!["Void".to_string()]),
+    )
 }
 
 #[derive(Debug)]
@@ -131,7 +140,7 @@ pub enum HirExpressionBase {
     HirIfExpression {
         cond_expr: Box<HirExpression>,
         then_exprs: Box<HirExpressions>,
-        else_exprs: Box<Option<HirExpressions>>,
+        else_exprs: Box<HirExpressions>, // may be a dummy expression
     },
     HirWhileExpression {
         cond_expr: Box<HirExpression>,
@@ -273,7 +282,7 @@ impl Hir {
         ty: TermTy,
         cond_hir: HirExpression,
         then_hir: HirExpressions,
-        else_hir: Option<HirExpressions>,
+        else_hir: HirExpressions,
     ) -> HirExpression {
         HirExpression {
             ty,

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -82,6 +82,14 @@ impl TermTy {
         }
     }
 
+    // Returns true when this is the Never type
+    pub fn is_never_type(&self) -> bool {
+        match self.body {
+            TyRaw => (self.fullname.0 == "Never"),
+            _ => false,
+        }
+    }
+
     pub fn meta_ty(&self) -> TermTy {
         match &self.body {
             TyRaw => ty::meta(&self.fullname.0),

--- a/src/type_checking/mod.rs
+++ b/src/type_checking/mod.rs
@@ -47,6 +47,20 @@ pub fn check_condition_ty(ty: &TermTy, on: &str) -> Result<(), Error> {
     }
 }
 
+pub fn check_if_clauses_ty(then_ty: &TermTy, else_ty: &TermTy) -> Result<(), Error> {
+    if then_ty.equals_to(else_ty) {
+        Ok(())
+    } else if then_ty.is_never_type() || else_ty.is_never_type() {
+        Ok(())
+    } else {
+        Err(type_error!(
+            "type of `if` clauses does not match (then: {}, else: {})",
+            then_ty,
+            else_ty
+        ))
+    }
+}
+
 pub fn check_reassign_var(orig_ty: &TermTy, new_ty: &TermTy, name: &str) -> Result<(), Error> {
     if orig_ty.equals_to(new_ty) {
         Ok(())


### PR DESCRIPTION
- If the type of either branch is Void, put refenence of `::Void` to
  the end of the exprs of the other branch so that both branch has
  the same type (i.e. `Void`).
- If the type of either branch is Never (i.e. `break`), the value of
  if-expr is the type of the other branch and do not use `phi` (or
  broken .ll is generated.)

fix #184 