### PR TITLE
fix 194

### DIFF
--- a/builtin/lambda.sk
+++ b/builtin/lambda.sk
@@ -1,9 +1,11 @@
 class Fn0<T>
   def initialize(
     func: Shiika::Internal::Ptr,
+    the_self: Object,
     captures: Array<Shiika::Internal::Ptr>,
   )
     @func = func
+    @the_self = the_self
     @captures = captures
   end
 end
@@ -11,9 +13,11 @@ end
 class Fn1<S1, T>
   def initialize(
     func: Shiika::Internal::Ptr,
+    the_self: Object,
     captures: Array<Shiika::Internal::Ptr>,
   )
     @func = func
+    @the_self = the_self
     @captures = captures
   end
 end
@@ -21,9 +25,11 @@ end
 class Fn2<S1, S2, T>
   def initialize(
     func: Shiika::Internal::Ptr,
+    the_self: Object,
     captures: Array<Shiika::Internal::Ptr>,
   )
     @func = func
+    @the_self = the_self
     @captures = captures
   end
 end
@@ -31,9 +37,11 @@ end
 class Fn3<S1, S2, S3, T>
   def initialize(
     func: Shiika::Internal::Ptr,
+    the_self: Object,
     captures: Array<Shiika::Internal::Ptr>,
   )
     @func = func
+    @the_self = the_self
     @captures = captures
   end
 end
@@ -41,9 +49,11 @@ end
 class Fn4<S1, S2, S3, S4, T>
   def initialize(
     func: Shiika::Internal::Ptr,
+    the_self: Object,
     captures: Array<Shiika::Internal::Ptr>,
   )
     @func = func
+    @the_self = the_self
     @captures = captures
   end
 end
@@ -51,9 +61,11 @@ end
 class Fn5<S1, S2, S3, S4, S5, T>
   def initialize(
     func: Shiika::Internal::Ptr,
+    the_self: Object,
     captures: Array<Shiika::Internal::Ptr>,
   )
     @func = func
+    @the_self = the_self
     @captures = captures
   end
 end
@@ -61,9 +73,11 @@ end
 class Fn6<S1, S2, S3, S4, S5, S6, T>
   def initialize(
     func: Shiika::Internal::Ptr,
+    the_self: Object,
     captures: Array<Shiika::Internal::Ptr>,
   )
     @func = func
+    @the_self = the_self
     @captures = captures
   end
 end
@@ -71,9 +85,11 @@ end
 class Fn7<S1, S2, S3, S4, S5, S6, S7, T>
   def initialize(
     func: Shiika::Internal::Ptr,
+    the_self: Object,
     captures: Array<Shiika::Internal::Ptr>,
   )
     @func = func
+    @the_self = the_self
     @captures = captures
   end
 end
@@ -81,9 +97,11 @@ end
 class Fn8<S1, S2, S3, S4, S5, S6, S7, S8, T>
   def initialize(
     func: Shiika::Internal::Ptr,
+    the_self: Object,
     captures: Array<Shiika::Internal::Ptr>,
   )
     @func = func
+    @the_self = the_self
     @captures = captures
   end
 end
@@ -91,9 +109,11 @@ end
 class Fn9<S1, S2, S3, S4, S5, S6, S7, S8, S9, T>
   def initialize(
     func: Shiika::Internal::Ptr,
+    the_self: Object,
     captures: Array<Shiika::Internal::Ptr>,
   )
     @func = func
+    @the_self = the_self
     @captures = captures
   end
 end

--- a/builtin/string.sk
+++ b/builtin/string.sk
@@ -44,15 +44,9 @@ class String
 
   # Call `f` for each byte
   def each_byte(f: Fn1<Int, Void>) 
-    var i = 0; while i < @bytesize
-      f.call(self.nth_byte(i))
-      i += 1
+    @bytesize.times do |i: Int|
+      f.call(nth_byte(i))
     end
-
-    # TODO #194
-    #@bytesize.times do |i: Int|
-    #  f.call(self.nth_byte(i))
-    #end
   end
 
   # Return true if `self` ends with `s`

--- a/src/code_gen/code_gen_context.rs
+++ b/src/code_gen/code_gen_context.rs
@@ -21,7 +21,7 @@ pub struct CodeGenContext<'hir: 'run, 'run> {
     pub lambdas: VecDeque<CodeGenLambda<'hir>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum FunctionOrigin {
     Method,
     Lambda,

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -10,6 +10,8 @@ use crate::ty::*;
 use inkwell::values::*;
 use std::rc::Rc;
 
+/// Index of @the_self of FnX
+const FN_X_THE_SELF_IDX: usize = 1;
 /// Index of @captures of FnX
 const FN_X_CAPTURES_IDX: usize = 2;
 
@@ -510,13 +512,13 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         ctx: &mut CodeGenContext<'hir, 'run>,
     ) -> Result<inkwell::values::BasicValueEnum, Error> {
         if ctx.function.get_name().to_str().unwrap() == "user_main" {
-            Ok(self.the_main.expect("[BUG] self.the_main is None"))
+            Ok(self.the_main.unwrap())
+        } else if ctx.function_origin == FunctionOrigin::Lambda {
+            let fn_x = ctx.function.get_first_param().unwrap();
+            Ok(self.build_ivar_load(fn_x, FN_X_THE_SELF_IDX, "the_main"))
         } else {
             // The first arg of llvm function is `self`
-            Ok(ctx
-                .function
-                .get_first_param()
-                .expect("[BUG] get_first_param() is None"))
+            Ok(ctx.function.get_first_param().unwrap())
         }
     }
 

--- a/src/code_gen/lambda.rs
+++ b/src/code_gen/lambda.rs
@@ -111,6 +111,6 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
         lvars: &[(String, TermTy)],
     ) -> Result<(), Error> {
         let ret_ty = &exprs.ty;
-        self.gen_llvm_func_body(&func_name, params, Right(exprs), lvars, &ret_ty)
+        self.gen_llvm_func_body(&func_name, params, Right(exprs), lvars, &ret_ty, true)
     }
 }

--- a/src/code_gen/mod.rs
+++ b/src/code_gen/mod.rs
@@ -447,18 +447,15 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
         is_lambda: bool,
     ) -> Result<(), Error> {
         // LLVM function
+        // (Function for lambdas are created in gen_lambda_expr)
         let function = self.get_llvm_func(func_name);
 
         // Set param names
         for (i, param) in function.get_param_iter().enumerate() {
-            let name = if is_lambda {
-                           &params[i].name
+            let name = if i == 0 {
+                           if is_lambda { "fn_x" } else { "self" }
                        } else {
-                           if i == 0 {
-                               "self"
-                           } else {
-                               &params[i - 1].name
-                           }
+                           &params[i - 1].name
                        };
             inkwell_set_name(param, name);
         }

--- a/src/corelib/fn_x.rs
+++ b/src/corelib/fn_x.rs
@@ -2,6 +2,9 @@ use crate::corelib::*;
 use inkwell::types::*;
 use inkwell::AddressSpace;
 
+/// Index of @func of FnX
+const FN_X_FUNC_IDX: usize = 0;
+
 macro_rules! create_fn_call {
     ($i:expr) => {{
         let args_str = (1..=$i)
@@ -17,7 +20,7 @@ macro_rules! create_fn_call {
             &format!("call({}) -> T", args_str),
             |code_gen, function| {
                 let fn_obj = function.get_params()[0];
-                let sk_ptr = code_gen.build_ivar_load(fn_obj, 0, "func");
+                let sk_ptr = code_gen.build_ivar_load(fn_obj, FN_X_FUNC_IDX, "func");
 
                 let mut args = vec![fn_obj];
                 for k in 1..=$i {

--- a/src/corelib/fn_x.rs
+++ b/src/corelib/fn_x.rs
@@ -18,22 +18,19 @@ macro_rules! create_fn_call {
             |code_gen, function| {
                 let fn_obj = function.get_params()[0];
                 let sk_ptr = code_gen.build_ivar_load(fn_obj, 0, "func");
-                let capary = code_gen.build_ivar_load(fn_obj, 1, "captures");
 
-                let mut args = vec![];
+                let mut args = vec![fn_obj];
                 for k in 1..=$i {
                     args.push(function.get_params()[k]);
                 }
-                args.push(capary);
 
                 // Create the type of lambda_xx()
+                let fn_x_type = code_gen.llvm_type(&ty::raw(&format!("Fn{}", $i)));
                 let obj_type = code_gen.llvm_type(&ty::raw("Object"));
-                let ary_type = code_gen.llvm_type(&ty::raw("Array"));
-                let mut arg_types = vec![];
+                let mut arg_types = vec![fn_x_type.into()];
                 for _ in 1..=$i {
                     arg_types.push(obj_type.into());
                 }
-                arg_types.push(ary_type.into());
                 let fntype = obj_type.fn_type(&arg_types, false);
                 let fnptype = fntype.ptr_type(AddressSpace::Generic);
 

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -409,8 +409,11 @@ impl HirMaker {
 
         let lvars = lambda_ctx.extract_lvars();
         let captures = self._resolve_lambda_captures(lambda_ctx.captures);
+
+        let name = format!("lambda_{}", lambda_id);
+        let ty = lambda_ty(&hir_params, &hir_exprs.ty);
         Ok(Hir::lambda_expr(
-            lambda_id, hir_params, hir_exprs, captures, lvars,
+            ty, name, hir_params, hir_exprs, captures, lvars,
         ))
     }
 
@@ -703,4 +706,10 @@ impl HirMaker {
         }
         panic!("[BUG] nearest_common_ancestor_type not found");
     }
+}
+
+fn lambda_ty(params: &[MethodParam], ret_ty: &TermTy) -> TermTy {
+    let mut tyargs = params.iter().map(|x| x.ty.clone()).collect::<Vec<_>>();
+    tyargs.push(ret_ty.clone());
+    ty::spe(&format!("Fn{}", params.len()), tyargs)
 }

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -394,18 +394,13 @@ impl Hir {
     }
 
     pub fn lambda_expr(
-        n: usize,
-        mut params: Vec<MethodParam>,
+        ty: TermTy,
+        name: String,
+        params: Vec<MethodParam>,
         exprs: HirExpressions,
         captures: Vec<HirLambdaCapture>,
         lvars: HirLVars,
     ) -> HirExpression {
-        let name = format!("lambda_{}", n);
-        let ty = lambda_ty(&params, &exprs.ty);
-        params.push(MethodParam {
-            name: "(captures)".to_string(),
-            ty: ty::ary(ty::raw("Object")),
-        });
         HirExpression {
             ty,
             node: HirExpressionBase::HirLambdaExpr {
@@ -496,11 +491,4 @@ impl Hir {
             },
         }
     }
-}
-
-fn lambda_ty(params: &[MethodParam], ret_ty: &TermTy) -> TermTy {
-    let i = params.len();
-    let mut tyargs = params.iter().map(|x| x.ty.clone()).collect::<Vec<_>>();
-    tyargs.push(ret_ty.clone());
-    ty::spe(&format!("Fn{}", i), tyargs)
 }


### PR DESCRIPTION
fix #194 
- [x] fix: LLVM funcs of lambda has wrong parameter name
- [x] FnX#call: pass `self` to lambda_xx (rather than just `captures`)
  - lambda_xx: Get `captures` from `self`
- [x] FnX: Add `@the_self`
  - gen_self_expression: refer `@the_self` is in lambda