### PR TITLE
String interpolation

### DIFF
--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -633,16 +633,22 @@ impl<'a> Lexer<'a> {
                 }
                 Some('\\') => {
                     next_cur.proceed(self.src);
-                    let c = self._read_escape_sequence(next_cur.peek(self.src));
-                    next_cur.proceed(self.src);
-                    buf.push(c);
+                    let c2 = next_cur.peek(self.src);
+                    if c2 == Some('{') {
+                        next_cur.proceed(self.src);
+                        return Token::StrWithInterpolation{ head: buf, inspect: true };
+                    } else {
+                        let c = self._read_escape_sequence(next_cur.peek(self.src));
+                        next_cur.proceed(self.src);
+                        buf.push(c);
+                    }
                 }
                 Some('#') => {
                     next_cur.proceed(self.src);
                     let c2 = next_cur.peek(self.src);
                     if c2 == Some('{') {
                         next_cur.proceed(self.src);
-                        return Token::StrWithInterpolation{ head: buf };
+                        return Token::StrWithInterpolation{ head: buf, inspect: false };
                     } else {
                         buf.push('#');
                     }

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -9,6 +9,9 @@ pub enum Token {
     IVar(String),
     Number(String),
     Str(String),
+    StrWithInterpolation {
+        head: String, // Contents before `#{'
+    },
     // Symbols
     LParen,       //  (
     RParen,       //  )
@@ -129,6 +132,7 @@ impl Token {
             Token::IVar(_) => true,
             Token::Number(_) => true,
             Token::Str(_) => true,
+            Token::StrWithInterpolation { .. } => true,
             // Symbols
             Token::LParen => true,        //  (
             Token::RParen => false,       //  )

--- a/src/parser/token.rs
+++ b/src/parser/token.rs
@@ -11,6 +11,7 @@ pub enum Token {
     Str(String),
     StrWithInterpolation {
         head: String, // Contents before `#{'
+        inspect: bool, // true if `\{}', which calls .inspect instead of .to_s
     },
     // Symbols
     LParen,       //  (

--- a/tests/sk/string.sk
+++ b/tests/sk/string.sk
@@ -3,6 +3,8 @@ var a = Array<String>.new
 # interpolation
 x = 1; y = 2
 unless "x=#{x}, y=#{y}" == "x=1, y=2"; puts "interpolation1: fail"; end
+b = [1,2,3]; c = [4,5]
+unless "b=\{b}, c=\{c}" == "b=[1, 2, 3], c=[4, 5]"; puts "interpolation2: fail"; end
 
 # split
 a = "a<>bc<>d".split("<>")

--- a/tests/sk/string.sk
+++ b/tests/sk/string.sk
@@ -1,5 +1,9 @@
 var a = Array<String>.new
 
+# interpolation
+x = 1; y = 2
+unless "x=#{x}, y=#{y}" == "x=1, y=2"; puts "interpolation1: fail"; end
+
 # split
 a = "a<>bc<>d".split("<>")
 unless a.length == 3; puts "split1: bad length"; end


### PR DESCRIPTION
This PR implements `#{}` in a string literal and also `\{}`, which calls .inspect instead of .to_s.