### PR TITLE
Add compile instructions on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ See [Issues](https://github.com/yhara/shiika/issues)
 - LLVM (`brew install llvm@9`)
 - bdw-gc (`brew install bdw-gc`)
 
+```sh
+export PATH="$(brew --prefix)/opt/llvm@9/bin":$PATH
+export LDFLAGS="-L$(brew --prefix)/opt/llvm@9/lib -L$(brew --prefix)/opt/bdw-gc/lib"
+export CPPFLAGS="-I$(brew --prefix)/opt/llvm@9/include"
+```
+
 ### Compile
 
 ```


### PR DESCRIPTION
The default hacking guide will leads to fail on macOS with homebrew.