### PR TITLE
impl. break from block 

### DIFF
--- a/builtin/_lambda.sk
+++ b/builtin/_lambda.sk
@@ -1,9 +1,13 @@
 class Fn
+  EXIT_NORMAL = 0
+  EXIT_BREAK = 1
+
   def initialize(
     @func: Shiika::Internal::Ptr,
     @the_self: Object,
     @captures: Array<Shiika::Internal::Ptr>,
   )
+    @exit_status = EXIT_NORMAL
   end
 end
 

--- a/builtin/_lambda.sk
+++ b/builtin/_lambda.sk
@@ -1,12 +1,9 @@
 class Fn
   def initialize(
-    func: Shiika::Internal::Ptr,
-    the_self: Object,
-    captures: Array<Shiika::Internal::Ptr>,
+    @func: Shiika::Internal::Ptr,
+    @the_self: Object,
+    @captures: Array<Shiika::Internal::Ptr>,
   )
-    @func = func
-    @the_self = the_self
-    @captures = captures
   end
 end
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -322,7 +322,11 @@ pub fn bin_op_expr(left: AstExpression, op: &str, right: AstExpression) -> AstEx
 }
 
 pub fn lambda_expr(params: Vec<Param>, exprs: Vec<AstExpression>, is_fn: bool) -> AstExpression {
-    primary_expression(AstExpressionBody::LambdaExpr { params, exprs, is_fn })
+    primary_expression(AstExpressionBody::LambdaExpr {
+        params,
+        exprs,
+        is_fn,
+    })
 }
 
 pub fn pseudo_variable(token: Token) -> AstExpression {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -110,6 +110,8 @@ pub enum AstExpressionBody {
     LambdaExpr {
         params: Vec<Param>,
         exprs: Vec<AstExpression>,
+        /// true if this is from `fn(){}`. false if this is a block (do-end/{})
+        is_fn: bool,
     },
     // Local variable reference or method call with implicit receiver(self)
     BareName(String),
@@ -319,8 +321,8 @@ pub fn bin_op_expr(left: AstExpression, op: &str, right: AstExpression) -> AstEx
     })
 }
 
-pub fn lambda_expr(params: Vec<Param>, exprs: Vec<AstExpression>) -> AstExpression {
-    primary_expression(AstExpressionBody::LambdaExpr { params, exprs })
+pub fn lambda_expr(params: Vec<Param>, exprs: Vec<AstExpression>, is_fn: bool) -> AstExpression {
+    primary_expression(AstExpressionBody::LambdaExpr { params, exprs, is_fn })
 }
 
 pub fn pseudo_variable(token: Token) -> AstExpression {

--- a/src/code_gen/code_gen_context.rs
+++ b/src/code_gen/code_gen_context.rs
@@ -17,7 +17,7 @@ pub struct CodeGenContext<'hir: 'run, 'run> {
     /// End of `while`, if any
     pub current_loop_end: Option<Rc<inkwell::basic_block::BasicBlock<'run>>>,
     /// End of the current llvm function. Only used for lambdas
-    pub current_func_end: Option<Rc<inkwell::basic_block::BasicBlock<'run>>>,
+    pub current_func_end: Rc<inkwell::basic_block::BasicBlock<'run>>,
     /// Lambdas to be compiled
     pub lambdas: VecDeque<CodeGenLambda<'hir>>,
 }
@@ -39,7 +39,7 @@ pub struct CodeGenLambda<'hir> {
 impl<'hir, 'run> CodeGenContext<'hir, 'run> {
     pub fn new(
         function: inkwell::values::FunctionValue<'run>,
-        function_end: Option<Rc<inkwell::basic_block::BasicBlock<'run>>>,
+        function_end: Rc<inkwell::basic_block::BasicBlock<'run>>,
         function_origin: FunctionOrigin,
         function_params: Option<&'hir [MethodParam]>,
         lvars: HashMap<String, inkwell::values::PointerValue<'run>>,

--- a/src/code_gen/code_gen_context.rs
+++ b/src/code_gen/code_gen_context.rs
@@ -1,6 +1,5 @@
 use crate::hir::*;
 use std::collections::HashMap;
-use std::collections::VecDeque;
 use std::rc::Rc;
 
 #[derive(Debug)]
@@ -18,8 +17,6 @@ pub struct CodeGenContext<'hir: 'run, 'run> {
     pub current_loop_end: Option<Rc<inkwell::basic_block::BasicBlock<'run>>>,
     /// End of the current llvm function. Only used for lambdas
     pub current_func_end: Rc<inkwell::basic_block::BasicBlock<'run>>,
-    /// Lambdas to be compiled
-    pub lambdas: VecDeque<CodeGenLambda<'hir>>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -51,7 +48,6 @@ impl<'hir, 'run> CodeGenContext<'hir, 'run> {
             lvars,
             current_loop_end: None,
             current_func_end: function_end,
-            lambdas: VecDeque::new(),
         }
     }
 }

--- a/src/code_gen/code_gen_context.rs
+++ b/src/code_gen/code_gen_context.rs
@@ -8,14 +8,16 @@ pub struct CodeGenContext<'hir: 'run, 'run> {
     /// Current llvm function
     pub function: inkwell::values::FunctionValue<'run>,
     /// If `function` corresponds to a lambda or a method
-    /// (llvm func of methods takes `self` as the first arg but lambdas do not)
     pub function_origin: FunctionOrigin,
     /// Parameters of `function`
     /// Only used for lambdas
     pub function_params: Option<&'hir [MethodParam]>,
     /// Ptr of local variables
     pub lvars: HashMap<String, inkwell::values::PointerValue<'run>>,
+    /// End of `while`, if any
     pub current_loop_end: Option<Rc<inkwell::basic_block::BasicBlock<'run>>>,
+    /// End of the current llvm function. Only used for lambdas
+    pub current_func_end: Option<Rc<inkwell::basic_block::BasicBlock<'run>>>,
     /// Lambdas to be compiled
     pub lambdas: VecDeque<CodeGenLambda<'hir>>,
 }
@@ -37,6 +39,7 @@ pub struct CodeGenLambda<'hir> {
 impl<'hir, 'run> CodeGenContext<'hir, 'run> {
     pub fn new(
         function: inkwell::values::FunctionValue<'run>,
+        function_end: Option<Rc<inkwell::basic_block::BasicBlock<'run>>>,
         function_origin: FunctionOrigin,
         function_params: Option<&'hir [MethodParam]>,
         lvars: HashMap<String, inkwell::values::PointerValue<'run>>,
@@ -47,6 +50,7 @@ impl<'hir, 'run> CodeGenContext<'hir, 'run> {
             function_params,
             lvars,
             current_loop_end: None,
+            current_func_end: function_end,
             lambdas: VecDeque::new(),
         }
     }

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -74,11 +74,10 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             HirLambdaExpr {
                 name,
                 params,
-                exprs,
                 captures,
-                lvars,
+                ret_ty,
                 ..
-            } => self.gen_lambda_expr(ctx, name, params, exprs, captures, lvars),
+            } => self.gen_lambda_expr(ctx, name, params, captures, ret_ty),
             HirSelfExpression => self.gen_self_expression(ctx, &expr.ty),
             HirArrayLiteral { exprs } => self.gen_array_literal(ctx, exprs),
             HirFloatLiteral { value } => Ok(self.gen_float_literal(*value)),
@@ -486,15 +485,13 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
         ctx: &mut CodeGenContext<'hir, 'run>,
         func_name: &str,
         params: &[MethodParam],
-        exprs: &'hir HirExpressions,
         captures: &'hir [HirLambdaCapture],
-        _lvars: &[(String, TermTy)],
+        ret_ty: &TermTy,
     ) -> Result<inkwell::values::BasicValueEnum, Error> {
         let fn_x_type = &ty::raw(&format!("Fn{}", params.len()));
         let obj_type = ty::raw("Object");
         let mut arg_types = (1..=params.len()).map(|_| &obj_type).collect::<Vec<_>>();
         arg_types.insert(0, &fn_x_type);
-        let ret_ty = &exprs.ty;
         let func_type = self.llvm_func_type(None, &arg_types, &ret_ty);
         self.module.add_function(&func_name, func_type, None);
 

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -253,7 +253,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
                 self.builder.build_unconditional_branch(*Rc::clone(b));
                 Ok(self.i32_type.const_int(0, false).as_basic_value_enum()) // return Void
             }
-            None => Err(error::program_error("break outside of a loop")),
+            None => Err(error::bug("break outside of a loop")),
         }
     }
 

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -96,7 +96,6 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
                 fullname,
                 str_literal_idx,
             } => Ok(self.gen_class_literal(fullname, str_literal_idx)),
-            _ => todo!(),
         }
     }
 

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -73,6 +73,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
                 exprs,
                 captures,
                 lvars,
+                ..
             } => self.gen_lambda_expr(ctx, name, params, exprs, captures, lvars),
             HirSelfExpression => self.gen_self_expression(ctx, &expr.ty),
             HirArrayLiteral { exprs } => self.gen_array_literal(ctx, exprs),

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -92,6 +92,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
                 fullname,
                 str_literal_idx,
             } => Ok(self.gen_class_literal(fullname, str_literal_idx)),
+            _ => todo!(),
         }
     }
 

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -48,7 +48,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
                 cond_expr,
                 body_exprs,
             } => self.gen_while_expr(ctx, &cond_expr, &body_exprs),
-            HirBreakExpression => self.gen_break_expr(ctx),
+            HirBreakExpression { from } => self.gen_break_expr(ctx, from),
             HirLVarAssign { name, rhs } => self.gen_lvar_assign(ctx, name, rhs),
             HirIVarAssign {
                 name,
@@ -248,6 +248,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
     fn gen_break_expr(
         &self,
         ctx: &mut CodeGenContext<'hir, 'run>,
+        _from: &HirBreakFrom,
     ) -> Result<inkwell::values::BasicValueEnum, Error> {
         match &ctx.current_loop_end {
             Some(b) => {

--- a/src/code_gen/lambda.rs
+++ b/src/code_gen/lambda.rs
@@ -99,6 +99,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
             HirLambdaCaptureWrite { rhs, .. } => self.gen_lambda_funcs_in_expr(rhs)?,
             HirBitCast { expr } => self.gen_lambda_funcs_in_expr(expr)?,
             HirClassLiteral { .. } => (),
+            _ => todo!(),
         }
         Ok(())
     }

--- a/src/code_gen/lambda.rs
+++ b/src/code_gen/lambda.rs
@@ -60,7 +60,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
                 self.gen_lambda_funcs_in_expr(cond_expr)?;
                 self.gen_lambda_funcs_in_exprs(&body_exprs.exprs)?;
             }
-            HirBreakExpression => (),
+            HirBreakExpression { .. } => (),
             HirLVarAssign { rhs, .. } => self.gen_lambda_funcs_in_expr(rhs)?,
             HirIVarAssign { rhs, .. } => self.gen_lambda_funcs_in_expr(rhs)?,
             HirConstAssign { rhs, .. } => self.gen_lambda_funcs_in_expr(rhs)?,

--- a/src/code_gen/lambda.rs
+++ b/src/code_gen/lambda.rs
@@ -112,6 +112,13 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
         ret_ty: &TermTy,
         lvars: &[(String, TermTy)],
     ) -> Result<(), Error> {
-        self.gen_llvm_func_body(&func_name, params, Right(exprs), lvars, ret_ty.is_void_type(), true)
+        self.gen_llvm_func_body(
+            &func_name,
+            params,
+            Right(exprs),
+            lvars,
+            ret_ty.is_void_type(),
+            true,
+        )
     }
 }

--- a/src/code_gen/lambda.rs
+++ b/src/code_gen/lambda.rs
@@ -100,7 +100,6 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
             HirLambdaCaptureWrite { rhs, .. } => self.gen_lambda_funcs_in_expr(rhs)?,
             HirBitCast { expr } => self.gen_lambda_funcs_in_expr(expr)?,
             HirClassLiteral { .. } => (),
-            _ => todo!(),
         }
         Ok(())
     }

--- a/src/code_gen/lambda.rs
+++ b/src/code_gen/lambda.rs
@@ -82,10 +82,11 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
                 name,
                 params,
                 exprs,
+                ret_ty,
                 lvars,
                 ..
             } => {
-                self.gen_lambda_func(name, params, exprs, lvars)?;
+                self.gen_lambda_func(name, params, exprs, ret_ty, lvars)?;
                 self.gen_lambda_funcs_in_exprs(&exprs.exprs)?;
             }
             HirSelfExpression => (),
@@ -109,9 +110,9 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
         func_name: &str,
         params: &'hir [MethodParam],
         exprs: &'hir HirExpressions,
+        ret_ty: &TermTy,
         lvars: &[(String, TermTy)],
     ) -> Result<(), Error> {
-        let ret_ty = &exprs.ty;
-        self.gen_llvm_func_body(&func_name, params, Right(exprs), lvars, &ret_ty, true)
+        self.gen_llvm_func_body(&func_name, params, Right(exprs), lvars, ret_ty.is_void_type(), true)
     }
 }

--- a/src/code_gen/mod.rs
+++ b/src/code_gen/mod.rs
@@ -51,9 +51,10 @@ pub fn run(mir: &Mir, outpath: &str) -> Result<(), Error> {
     let builder = context.create_builder();
     let mut code_gen = CodeGen::new(&mir, &context, &module, &builder);
     code_gen.gen_program(&mir.hir)?;
-    code_gen.module.print_to_file(outpath).map_err(|llvm_str| {
-        error::plain_runner_error(llvm_str.to_string())
-    })?;
+    code_gen
+        .module
+        .print_to_file(outpath)
+        .map_err(|llvm_str| error::plain_runner_error(llvm_str.to_string()))?;
     Ok(())
 }
 

--- a/src/code_gen/mod.rs
+++ b/src/code_gen/mod.rs
@@ -482,22 +482,12 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
             Left(method_body) => match method_body {
                 SkMethodBody::RustMethodBody { gen } => gen(self, &function)?,
                 SkMethodBody::RustClosureMethodBody { boxed_gen } => boxed_gen(self, &function)?,
-                SkMethodBody::ShiikaMethodBody { exprs } => self.gen_shiika_method_body(
-                    function,
-                    None,
-                    is_void,
-                    &exprs,
-                    lvar_ptrs,
-                )?,
+                SkMethodBody::ShiikaMethodBody { exprs } => {
+                    self.gen_shiika_method_body(function, None, is_void, &exprs, lvar_ptrs)?
+                }
             },
             Right(exprs) => {
-                self.gen_shiika_lambda_body(
-                    function,
-                    Some(params),
-                    is_void,
-                    &exprs,
-                    lvar_ptrs,
-                )?;
+                self.gen_shiika_lambda_body(function, Some(params), is_void, &exprs, lvar_ptrs)?;
             }
         }
         Ok(())
@@ -634,13 +624,7 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
         let end_block = self.context.append_basic_block(function, "End");
         let ref_end_block1 = Rc::new(end_block);
         let ref_end_block2 = Rc::clone(&ref_end_block1);
-        let ctx = CodeGenContext::new(
-            function,
-            ref_end_block1,
-            origin,
-            function_params,
-            lvars,
-        );
+        let ctx = CodeGenContext::new(function, ref_end_block1, origin, function_params, lvars);
         (ref_end_block2, ctx)
     }
 }

--- a/src/corelib/fn_x.rs
+++ b/src/corelib/fn_x.rs
@@ -104,6 +104,15 @@ fn ivars() -> HashMap<String, SkIVar> {
             readonly: true,
         },
     );
+    ivars.insert(
+        "@exit_status".to_string(),
+        SkIVar {
+            name: "@exit_status".to_string(),
+            idx: 3,
+            ty: ty::raw("Int"),
+            readonly: false,
+        },
+    );
     ivars
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -88,6 +88,15 @@ pub fn plain_runner_error(msg: impl Into<String>) -> Error {
     }
 }
 
+pub fn bug(msg: impl Into<String>) -> Error {
+    Error {
+        msg: msg.into(),
+        backtrace: backtrace::Backtrace::new(),
+        details: ErrorDetails::Bug,
+        source: None,
+    }
+}
+
 pub fn must_be_some<T>(o: Option<T>, msg: String) -> T {
     o.unwrap_or_else(|| panic!(msg))
 }

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -105,7 +105,7 @@ impl HirMaker {
                 ..
             } => self.convert_method_call(receiver_expr, method_name, arg_exprs, type_args),
 
-            AstExpressionBody::LambdaExpr { params, exprs } => {
+            AstExpressionBody::LambdaExpr { params, exprs, .. } => {
                 self.convert_lambda_expr(params, exprs)
             }
 
@@ -198,7 +198,11 @@ impl HirMaker {
         let cond_hir = self.convert_expr(cond_expr)?;
         type_checking::check_condition_ty(&cond_hir.ty, "while")?;
 
+        let mut current = CtxKind::While;
+        std::mem::swap(&mut current, &mut self.ctx.current);
         let body_hirs = self.convert_exprs(body_exprs)?;
+        std::mem::swap(&mut current, &mut self.ctx.current);
+
         Ok(Hir::while_expression(cond_hir, body_hirs))
     }
 

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -207,6 +207,7 @@ impl HirMaker {
     }
 
     fn convert_break_expr(&mut self) -> Result<HirExpression, Error> {
+        let from;
         if self.ctx.current == CtxKind::Lambda {
             let lambda_ctx = self.ctx.lambda_mut();
             if lambda_ctx.is_fn {
@@ -215,11 +216,14 @@ impl HirMaker {
                 // OK for now. This `break` still may be invalid
                 // (eg. `ary.map{ break }`) but it cannot be checked here
                 lambda_ctx.has_break = true;
+                from = HirBreakFrom::Block;
             }
-        } else if self.ctx.current != CtxKind::While {
+        } else if self.ctx.current == CtxKind::While {
+            from = HirBreakFrom::While;
+        } else {
             return Err(error::program_error("`break' outside of a loop"));
         }
-        Ok(Hir::break_expression())
+        Ok(Hir::break_expression(from))
     }
 
     fn convert_lvar_assign(

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -207,6 +207,9 @@ impl HirMaker {
     }
 
     fn convert_break_expr(&mut self) -> Result<HirExpression, Error> {
+        if self.ctx.current != CtxKind::While {
+            return Err(error::program_error("`break' outside of a loop"));
+        }
         Ok(Hir::break_expression())
     }
 

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -105,9 +105,11 @@ impl HirMaker {
                 ..
             } => self.convert_method_call(receiver_expr, method_name, arg_exprs, type_args),
 
-            AstExpressionBody::LambdaExpr { params, exprs, is_fn } => {
-                self.convert_lambda_expr(params, exprs, is_fn)
-            }
+            AstExpressionBody::LambdaExpr {
+                params,
+                exprs,
+                is_fn,
+            } => self.convert_lambda_expr(params, exprs, is_fn),
 
             AstExpressionBody::BareName(name) => self.convert_bare_name(name),
 

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -199,9 +199,9 @@ impl HirMaker {
         type_checking::check_condition_ty(&cond_hir.ty, "while")?;
 
         let mut current = CtxKind::While;
-        std::mem::swap(&mut current, &mut self.ctx.current);
+        self.ctx.swap_current(&mut current);
         let body_hirs = self.convert_exprs(body_exprs)?;
-        std::mem::swap(&mut current, &mut self.ctx.current);
+        self.ctx.swap_current(&mut current);
 
         Ok(Hir::while_expression(cond_hir, body_hirs))
     }
@@ -414,10 +414,10 @@ impl HirMaker {
         // Convert lambda body
         self.ctx.lambdas.push(LambdaCtx::new(hir_params.clone()));
 
-        let orig_current = self.ctx.current.clone();
-        self.ctx.current = CtxKind::Lambda;
+        let mut current = CtxKind::Lambda;
+        self.ctx.swap_current(&mut current);
         let hir_exprs = self.convert_exprs(exprs)?;
-        self.ctx.current = orig_current;
+        self.ctx.swap_current(&mut current);
 
         let mut lambda_ctx = self.ctx.lambdas.pop().unwrap();
         Ok(Hir::lambda_expr(

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -434,7 +434,9 @@ impl HirMaker {
         );
 
         // Convert lambda body
-        self.ctx.lambdas.push(LambdaCtx::new(*is_fn, hir_params.clone()));
+        self.ctx
+            .lambdas
+            .push(LambdaCtx::new(*is_fn, hir_params.clone()));
 
         let mut current = CtxKind::Lambda;
         self.ctx.swap_current(&mut current);

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -124,8 +124,8 @@ impl HirMaker {
         defs: &[ast::Definition],
     ) -> Result<(), Error> {
         let meta_name = fullname.meta_name();
-        let orig_current = self.ctx.current.clone();
-        self.ctx.current = CtxKind::Class;
+        let mut current = CtxKind::Class;
+        self.ctx.swap_current(&mut current);
         self.ctx.classes.push(ClassCtx::new(fullname.clone()));
 
         // Register constants before processing #initialize
@@ -172,7 +172,7 @@ impl HirMaker {
             }
         }
         self.ctx.classes.pop();
-        self.ctx.current = orig_current;
+        self.ctx.swap_current(&mut current);
         Ok(())
     }
 
@@ -322,10 +322,10 @@ impl HirMaker {
 
         self.ctx.method = Some(MethodCtx::new(signature.clone(), super_ivars));
 
-        let orig_current = self.ctx.current.clone();
-        self.ctx.current = CtxKind::Method;
+        let mut current = CtxKind::Method;
+        self.ctx.swap_current(&mut current);
         let hir_exprs = self.convert_exprs(body_exprs)?;
-        self.ctx.current = orig_current;
+        self.ctx.swap_current(&mut current);
 
         let mut method_ctx = self.ctx.method.take().unwrap();
         let lvars = extract_lvars(&mut method_ctx.lvars);

--- a/src/hir/hir_maker_context.rs
+++ b/src/hir/hir_maker_context.rs
@@ -76,12 +76,14 @@ impl MethodCtx {
 pub struct LambdaCtx {
     /// true if this lambda is `fn(){}`. false if it is a block (`do..end`,`{...}`)
     pub is_fn: bool,
-    /// Parameters of the current lambda
+    /// Parameters of the lambda
     pub params: Vec<MethodParam>,
     /// Current local variables
     pub lvars: HashMap<String, CtxLVar>,
     /// List of free variables captured in this context
     pub captures: Vec<LambdaCapture>,
+    /// true if this lambda has `break`
+    pub has_break: bool,
 }
 
 impl LambdaCtx {
@@ -91,6 +93,7 @@ impl LambdaCtx {
             params,
             lvars: Default::default(),
             captures: Default::default(),
+            has_break: false,
         }
     }
 }
@@ -145,8 +148,8 @@ impl HirMakerContext {
     }
 
     /// Returns the nearest lambda ctx
-    pub fn lambda(&self) -> &LambdaCtx {
-        self.lambdas.last().unwrap()
+    pub fn lambda_mut(&mut self) -> &mut LambdaCtx {
+        self.lambdas.last_mut().unwrap()
     }
 
     /// Returns the current namespace

--- a/src/hir/hir_maker_context.rs
+++ b/src/hir/hir_maker_context.rs
@@ -74,6 +74,8 @@ impl MethodCtx {
 
 #[derive(Debug)]
 pub struct LambdaCtx {
+    /// true if this lambda is `fn(){}`. false if it is a block (`do..end`,`{...}`)
+    pub is_fn: bool,
     /// Parameters of the current lambda
     pub params: Vec<MethodParam>,
     /// Current local variables
@@ -83,8 +85,9 @@ pub struct LambdaCtx {
 }
 
 impl LambdaCtx {
-    pub fn new(params: Vec<MethodParam>) -> LambdaCtx {
+    pub fn new(is_fn: bool, params: Vec<MethodParam>) -> LambdaCtx {
         LambdaCtx {
+            is_fn,
             params,
             lvars: Default::default(),
             captures: Default::default(),
@@ -139,6 +142,11 @@ impl HirMakerContext {
     /// Set `c` to `self.current` and the original value to `c`
     pub fn swap_current(&mut self, c: &mut CtxKind) {
         std::mem::swap(c, &mut self.current);
+    }
+
+    /// Returns the nearest lambda ctx
+    pub fn lambda(&self) -> &LambdaCtx {
+        self.lambdas.last().unwrap()
     }
 
     /// Returns the current namespace

--- a/src/hir/hir_maker_context.rs
+++ b/src/hir/hir_maker_context.rs
@@ -136,6 +136,11 @@ impl HirMakerContext {
         }
     }
 
+    /// Set `c` to `self.current` and the original value to `c`
+    pub fn swap_current(&mut self, c: &mut CtxKind) {
+        std::mem::swap(c, &mut self.current);
+    }
+
     /// Returns the current namespace
     pub fn namespace(&self) -> &str {
         if let Some(class_ctx) = self.classes.last() {

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -152,7 +152,9 @@ pub enum HirExpressionBase {
         cond_expr: Box<HirExpression>,
         body_exprs: Box<HirExpressions>,
     },
-    HirBreakExpression,
+    HirBreakExpression {
+        from: HirBreakFrom,
+    },
     HirLVarAssign {
         name: String,
         rhs: Box<HirExpression>,
@@ -258,6 +260,13 @@ pub enum HirLambdaCapture {
     CaptureFwd { cidx: usize, ty: TermTy },
 }
 
+/// Denotes what a `break` escapes from
+#[derive(Debug)]
+pub enum HirBreakFrom {
+    While,
+    Block,
+}
+
 impl Hir {
     pub fn expressions(exprs: Vec<HirExpression>) -> HirExpressions {
         HirExpressions::new(exprs)
@@ -318,10 +327,10 @@ impl Hir {
         }
     }
 
-    pub fn break_expression() -> HirExpression {
+    pub fn break_expression(from: HirBreakFrom) -> HirExpression {
         HirExpression {
             ty: ty::raw("Never"),
-            node: HirExpressionBase::HirBreakExpression {},
+            node: HirExpressionBase::HirBreakExpression { from },
         }
     }
 

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -173,6 +173,11 @@ pub enum HirExpressionBase {
         method_fullname: MethodFullname,
         arg_exprs: Vec<HirExpression>,
     },
+    HirInvokeLambda {
+        receiver_expr: Box<HirExpression>,
+        method_fullname: MethodFullname,
+        arg_exprs: Vec<HirExpression>,
+    },
     HirArgRef {
         idx: usize,
     },
@@ -358,6 +363,22 @@ impl Hir {
     }
 
     pub fn method_call(
+        result_ty: TermTy,
+        receiver_hir: HirExpression,
+        method_fullname: MethodFullname,
+        arg_hirs: Vec<HirExpression>,
+    ) -> HirExpression {
+        HirExpression {
+            ty: result_ty,
+            node: HirExpressionBase::HirMethodCall {
+                receiver_expr: Box::new(receiver_hir),
+                method_fullname,
+                arg_exprs: arg_hirs,
+            },
+        }
+    }
+
+    pub fn invoke_lambda(
         result_ty: TermTy,
         receiver_hir: HirExpression,
         method_fullname: MethodFullname,

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -198,6 +198,8 @@ pub enum HirExpressionBase {
         exprs: HirExpressions,
         captures: Vec<HirLambdaCapture>,
         lvars: HirLVars,
+        /// true if there is a `break` in this lambda
+        has_break: bool,
     },
     HirSelfExpression,
     HirArrayLiteral {
@@ -429,6 +431,7 @@ impl Hir {
         exprs: HirExpressions,
         captures: Vec<HirLambdaCapture>,
         lvars: HirLVars,
+        has_break: bool,
     ) -> HirExpression {
         HirExpression {
             ty,
@@ -438,6 +441,7 @@ impl Hir {
                 exprs,
                 captures,
                 lvars,
+                has_break,
             },
         }
     }

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -175,11 +175,6 @@ pub enum HirExpressionBase {
         method_fullname: MethodFullname,
         arg_exprs: Vec<HirExpression>,
     },
-    HirInvokeLambda {
-        receiver_expr: Box<HirExpression>,
-        method_fullname: MethodFullname,
-        arg_exprs: Vec<HirExpression>,
-    },
     HirArgRef {
         idx: usize,
     },

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -200,6 +200,7 @@ pub enum HirExpressionBase {
         exprs: HirExpressions,
         captures: Vec<HirLambdaCapture>,
         lvars: HirLVars,
+        ret_ty: TermTy,
         /// true if there is a `break` in this lambda
         has_break: bool,
     },
@@ -442,6 +443,7 @@ impl Hir {
         lvars: HirLVars,
         has_break: bool,
     ) -> HirExpression {
+        let ret_ty = exprs.ty.clone();
         HirExpression {
             ty,
             node: HirExpressionBase::HirLambdaExpr {
@@ -450,6 +452,7 @@ impl Hir {
                 exprs,
                 captures,
                 lvars,
+                ret_ty,
                 has_break,
             },
         }

--- a/src/names.rs
+++ b/src/names.rs
@@ -109,6 +109,18 @@ impl std::fmt::Display for MethodFullname {
     }
 }
 
+impl MethodFullname {
+    /// Returns true if this is any of `Fn0#call`, ..., `Fn9#call`
+    pub fn is_fn_x_call(&self) -> bool {
+        for i in 0..=9 {
+            if self.full_name == format!("Fn{}#call", i) {
+                return true;
+            }
+        }
+        false
+    }
+}
+
 #[derive(Debug, PartialEq, Clone, Eq, Hash)]
 pub struct ConstFirstname(pub String);
 

--- a/src/parser/expression_parser.rs
+++ b/src/parser/expression_parser.rs
@@ -879,6 +879,7 @@ impl<'a> Parser<'a> {
         Ok(ConstName { names, args })
     }
 
+    /// Parse `fn(){}`
     fn parse_lambda(&mut self) -> Result<AstExpression, Error> {
         self.lv += 1;
         self.debug_log("parse_lambda");
@@ -891,7 +892,7 @@ impl<'a> Parser<'a> {
         let exprs = self.parse_exprs(vec![Token::RBrace])?;
         assert!(self.consume(Token::RBrace));
         self.lv -= 1;
-        Ok(ast::lambda_expr(params, exprs))
+        Ok(ast::lambda_expr(params, exprs, true))
     }
 
     fn parse_parenthesized_expr(&mut self) -> Result<AstExpression, Error> {
@@ -1103,7 +1104,7 @@ impl<'a> Parser<'a> {
         let body_exprs = self.parse_exprs(vec![Token::KwEnd])?;
         self.expect(Token::KwEnd)?;
         self.lv -= 1;
-        Ok(ast::lambda_expr(block_params, body_exprs))
+        Ok(ast::lambda_expr(block_params, body_exprs, false))
     }
 
     /// Parse `{|..| ...}`
@@ -1121,7 +1122,7 @@ impl<'a> Parser<'a> {
         let body_exprs = self.parse_exprs(vec![Token::RBrace])?;
         self.expect(Token::RBrace)?;
         self.lv -= 1;
-        Ok(ast::lambda_expr(block_params, body_exprs))
+        Ok(ast::lambda_expr(block_params, body_exprs, false))
     }
 
     /// Parse `|a, b, ...|`

--- a/tests/sk/loops_and_conditionals.sk
+++ b/tests/sk/loops_and_conditionals.sk
@@ -1,16 +1,25 @@
 # while
 var i = 0
 while i < 3
-  i = i + 1
+  i += 1
 end
 unless i == 3 then puts "ng 1" end
+
+# while in lambda
+[3].each do |n: Int|
+  i = 0; while i < n
+    i += 1
+    break if i == 2
+  end
+end
+unless i == 2 then puts "ng: while in lambda" end
 
 # break
 i = 0
 while i < 3
   if i == 3 then break end
   if i == 2 then break end
-  i = i + 1
+  i += 1
 end
 unless i == 2 then puts "ng 2" end
 

--- a/tests/sk/loops_and_conditionals.sk
+++ b/tests/sk/loops_and_conditionals.sk
@@ -23,4 +23,13 @@ while i < 3
 end
 unless i == 2 then puts "ng 2" end
 
+# break from block
+var n = 0
+[1, 2, 3].each{|i: Int|
+  n += i
+  break if i == 2
+  n += i
+}
+unless n == 4 then puts "ng: break from block" end
+
 puts "ok"


### PR DESCRIPTION
- [x] ast: Add is_fn to LambdaExpr
- [x] hir: Add ~~`in_while`~~ `CtxKind::While` to ctx. Raise error if break is outside while
- [x] hir: Add ~~`current_lambda_is_fn` to ctx~~ `is_fn` to `LambdaCtx`
- [x] builtin: Add exit_status, ~~is_fn~~ to FnX
- ~~[ ] hir: Set FnX#is_fn~~
- [x] hir: Add `from` to `HirBreakExpression` (from while or from a block)
- [x] hir: Check break in lambda
  - [x] program error if (there is no `while` and) the nearest ctx is fn
  - [x] program error if (there is no `while` and) the nearest ctx is block but the current method does not return Void
- [ ] ~~hir: Add HirLambdaCall~~
- [ ] ~~hir: Convert invocation of FnX#call to HirLambdaCall~~
- [x] codegen: ~~gen_lambda_call~~
  - Invoke FnX#call
  - After that, depending on FnX#exit_status:
    - Do nothing if it has exited normally
    - Jump to the end of current method if it has exited with `break`
- [x] test: Add test
- [ ] doc: Update doc/shg

fix #177