### PR TITLE
Refactor HirMakerContext

### DIFF
--- a/doc/shg/src/hir.md
+++ b/doc/shg/src/hir.md
@@ -20,3 +20,23 @@ File: `src/hir/hir_maker.rs`, `convert_exprs.rs`
 
 These two files contains the main process of converting AST into HIR.
 
+## Lambda
+
+Instances of `Fn` are called "lambda" in Shiika. There are two ways to create a lambda:
+
+1. `fn(){ ...}` (called "fn")
+2. `do ... end`, `{ ... }` (called "block")
+
+A lambda can capture outer variables.
+
+```
+var a = 1
+f = fn(){ p a }
+a = 2
+f() #=> prints `2`
+```
+
+`HirLambdaExpr` contains `captures`, a list of `HirLambdaCapture`. To make this:
+
+1. When referring/updating a local variable defined in outer scope, save a `LambdaCapture` to `captures` of `LambdaCtx`.
+2. Once all exprs in a lambda are processed, convert each `LambdaCapture` to `HirLambdaCapture`.

--- a/src/code_gen/gen_exprs.rs
+++ b/src/code_gen/gen_exprs.rs
@@ -84,7 +84,7 @@ impl<'hir, 'run, 'ictx> CodeGen<'hir, 'run, 'ictx> {
             HirLambdaCaptureRef { idx, readonly } => {
                 self.gen_lambda_capture_ref(ctx, idx, !readonly, &expr.ty)
             }
-            HirLambdaCaptureWrite { cidx, rhs, .. } => {
+            HirLambdaCaptureWrite { cidx, rhs } => {
                 self.gen_lambda_capture_write(ctx, cidx, rhs, &rhs.ty)
             }
             HirBitCast { expr: target } => self.gen_bitcast(ctx, target, &expr.ty),

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -238,12 +238,9 @@ impl HirMaker {
         is_var: &bool,
     ) -> Result<HirExpression, Error> {
         let expr = self.convert_expr(rhs)?;
-        let ctx = self.method_ctx().ok_or_else(|| {
-            error::program_error(&format!("cannot assign ivar `{}' out of a method", name))
-        })?;
         let self_ty = self.ctx.self_ty();
 
-        if ctx.kind == CtxKind::Initializer {
+        if self.ctx.in_initializer() {
             let idx = self.declare_ivar(name, &expr.ty, !is_var)?;
             return Ok(Hir::ivar_assign(name, idx, expr, *is_var, self_ty.clone()));
         }

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -293,10 +293,10 @@ impl HirMaker {
     /// Declare a new ivar
     fn declare_ivar(&mut self, name: &str, ty: &TermTy, readonly: bool) -> Result<usize, Error> {
         let ctx = self.ctx_mut();
-        let (super_ivars, iivars) = if let CtxBody::Initializer {
+        let (super_ivars, iivars) = if let CtxDetail::Initializer {
             super_ivars,
             iivars,
-        } = &mut ctx.body
+        } = &mut ctx.detail
         {
             (super_ivars, iivars)
         } else {
@@ -614,7 +614,7 @@ impl HirMaker {
         })?;
         let self_cls = &method_ctx.self_ty.fullname;
         let mut found = self.class_dict.find_ivar(&self_cls, name);
-        if let CtxBody::Initializer { iivars, .. } = &method_ctx.body {
+        if let CtxDetail::Initializer { iivars, .. } = &method_ctx.detail {
             found = found.or_else(|| iivars.get(name))
         };
         match found {

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -296,6 +296,7 @@ impl HirMaker {
         let (super_ivars, iivars) = if let CtxDetail::Initializer {
             super_ivars,
             iivars,
+            ..
         } = &mut ctx.detail
         {
             (super_ivars, iivars)

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -430,8 +430,8 @@ impl HirMaker {
         );
 
         // Convert lambda body
-        self.push_ctx(HirMakerContext::lambda_ctx(self.ctx(), hir_params.clone()));
-        self.ctx.lambdas.push(LambdaCtx::new());
+        self.push_ctx(HirMakerContext::lambda_ctx(self.ctx()));
+        self.ctx.lambdas.push(LambdaCtx::new(hir_params.clone()));
         let hir_exprs = self.convert_exprs(exprs)?;
         let mut lambda_ctx = self.pop_ctx();
         let captures = self.ctx.lambdas.pop().unwrap().captures;
@@ -507,7 +507,7 @@ impl HirMaker {
             }
         }
         // Arg
-        if let Some((idx, param)) = ctx.find_fn_arg(name) {
+        if let Some((idx, param)) = self.ctx.find_fn_arg(name) {
             if updating {
                 return Err(error::program_error(&format!(
                     "you cannot reassign to argument `{}'",
@@ -569,7 +569,7 @@ impl HirMaker {
             )));
         }
         // Check argument
-        if let Some((idx, param)) = ctx.find_fn_arg(name) {
+        if let Some((idx, param)) = self.ctx.find_fn_arg(name) {
             if updating {
                 return Err(error::program_error(&format!(
                     "you cannot reassign to argument `{}'",

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -596,7 +596,7 @@ impl HirMaker {
             return Some((found, fullname));
         }
 
-        let fullname = name.under_namespace(&(self.ctx().namespace.0.clone()));
+        let fullname = name.under_namespace(&self.ctx.namespace());
         self.constants.get(&fullname).map(|found| (found, fullname))
     }
 

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -408,7 +408,6 @@ impl HirMaker {
         );
 
         // Convert lambda body
-        self.push_ctx(HirMakerContext::lambda_ctx(self.ctx()));
         self.ctx.lambdas.push(LambdaCtx::new(hir_params.clone()));
 
         let orig_current = self.ctx.current.clone();
@@ -416,7 +415,6 @@ impl HirMaker {
         let hir_exprs = self.convert_exprs(exprs)?;
         self.ctx.current = orig_current;
 
-        self.pop_ctx();
         let mut lambda_ctx = self.ctx.lambdas.pop().unwrap();
         Ok(Hir::lambda_expr(
             lambda_ty(&hir_params, &hir_exprs.ty), // ty

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -255,7 +255,7 @@ impl HirMaker {
             error::program_error(&format!("cannot assign ivar `{}' out of a method", name))
         })?;
 
-        if ctx.is_initializer {
+        if ctx.kind == CtxKind::Initializer {
             let self_ty = ctx.self_ty.clone();
             let idx = self.declare_ivar(name, &expr.ty, !is_var)?;
             return Ok(Hir::ivar_assign(name, idx, expr, *is_var, self_ty));

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -329,7 +329,7 @@ impl HirMaker {
         let body_exprs = self.convert_exprs(body_exprs)?;
         let mut method_ctx = self.pop_ctx();
         let lvars = method_ctx.extract_lvars();
-        let iivars = if let CtxBody::Initializer { iivars, .. } = method_ctx.body {
+        let iivars = if let CtxDetail::Initializer { iivars, .. } = method_ctx.detail {
             iivars
         } else {
             Default::default()

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -340,7 +340,11 @@ impl HirMaker {
         let body_exprs = self.convert_exprs(body_exprs)?;
         let mut method_ctx = self.pop_ctx();
         let lvars = method_ctx.extract_lvars();
-        let iivars = method_ctx.iivars;
+        let iivars = if let CtxBody::Initializer { iivars, .. } = method_ctx.body {
+            iivars
+        } else {
+            Default::default()
+        };
         type_checking::check_return_value(&self.class_dict, &signature, &body_exprs.ty)?;
 
         let body = SkMethodBody::ShiikaMethodBody { exprs: body_exprs };

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -105,14 +105,9 @@ impl HirMaker {
     fn process_toplevel_def(&mut self, def: &ast::Definition) -> Result<(), Error> {
         match def {
             // Extract instance/class methods
-            ast::Definition::ClassDefinition {
-                name,
-                defs,
-                typarams,
-                ..
-            } => {
+            ast::Definition::ClassDefinition { name, defs, .. } => {
                 let full = name.add_namespace("");
-                self.process_defs_in_class(&full, typarams.clone(), defs)?;
+                self.process_defs_in_class(&full, defs)?;
             }
             ast::Definition::ConstDefinition { name, expr } => {
                 self.register_const(name, expr)?;
@@ -126,11 +121,10 @@ impl HirMaker {
     fn process_defs_in_class(
         &mut self,
         fullname: &ClassFullname,
-        typarams: Vec<String>,
         defs: &[ast::Definition],
     ) -> Result<(), Error> {
         let meta_name = fullname.meta_name();
-        let ctx = HirMakerContext::class_ctx(&fullname, typarams, self.next_ctx_depth());
+        let ctx = HirMakerContext::class_ctx(&fullname, self.next_ctx_depth());
         self.push_ctx(ctx);
 
         // Register constants before processing #initialize
@@ -170,14 +164,9 @@ impl HirMaker {
                 ast::Definition::ConstDefinition { .. } => {
                     // Already processed above
                 }
-                ast::Definition::ClassDefinition {
-                    name,
-                    typarams,
-                    defs,
-                    ..
-                } => {
+                ast::Definition::ClassDefinition { name, defs, .. } => {
                     let full = name.add_namespace(&fullname.0);
-                    self.process_defs_in_class(&full, typarams.clone(), defs)?;
+                    self.process_defs_in_class(&full, defs)?;
                 }
             }
         }

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -134,7 +134,7 @@ impl HirMaker {
         self.push_ctx(ctx);
         let orig_current = self.ctx.current.clone();
         self.ctx.current = CtxKind::Class;
-        self.ctx.classes.push(ClassCtx::new());
+        self.ctx.classes.push(ClassCtx::new(fullname.clone()));
 
         // Register constants before processing #initialize
         self._process_const_defs_in_class(defs, fullname)?;

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -232,7 +232,7 @@ impl HirMaker {
             .class_dict
             .get_superclass(class_fullname)
             .map(|super_cls| super_cls.ivars.clone());
-        self.convert_method_def_(class_fullname, name, body_exprs, true, super_ivars)
+        self.convert_method_def_(class_fullname, name, body_exprs, super_ivars)
     }
 
     /// Create .new
@@ -306,7 +306,7 @@ impl HirMaker {
         body_exprs: &[AstExpression],
     ) -> Result<SkMethod, Error> {
         let (sk_method, _ivars) =
-            self.convert_method_def_(class_fullname, name, body_exprs, false, None)?;
+            self.convert_method_def_(class_fullname, name, body_exprs, None)?;
         Ok(sk_method)
     }
 
@@ -316,7 +316,6 @@ impl HirMaker {
         class_fullname: &ClassFullname,
         name: &MethodFirstname,
         body_exprs: &[AstExpression],
-        is_initializer: bool,
         super_ivars: Option<SkIVars>,
     ) -> Result<(SkMethod, HashMap<String, SkIVar>), Error> {
         // MethodSignature is built beforehand by class_dict::new
@@ -330,11 +329,7 @@ impl HirMaker {
             .expect(&err)
             .clone();
 
-        let method_ctx = if is_initializer {
-            HirMakerContext::initializer_ctx(self.ctx())
-        } else {
-            HirMakerContext::method_ctx(self.ctx())
-        };
+        let method_ctx = HirMakerContext::method_ctx(self.ctx());
         self.push_ctx(method_ctx);
         self.ctx.method = Some(MethodCtx::new(signature.clone(), super_ivars));
 

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -20,7 +20,7 @@ pub struct HirMaker {
     /// List of string literals found so far
     pub(super) str_literals: Vec<String>,
     /// Contextual information
-    pub(super) ctx: HirMakerContext_,
+    pub(super) ctx: HirMakerContext,
     /// Counter to give unique name for lambdas
     pub(super) lambda_ct: usize,
 }
@@ -50,7 +50,7 @@ impl HirMaker {
             constants: HashMap::new(),
             const_inits: vec![],
             str_literals: vec![],
-            ctx: HirMakerContext_::new(),
+            ctx: HirMakerContext::new(),
             lambda_ct: 0,
         }
     }

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -137,7 +137,8 @@ impl HirMaker {
         self._process_const_defs_in_class(defs, fullname)?;
 
         // Register #initialize and ivars
-        let own_ivars = self._process_initialize(fullname, defs.iter().find(|d| d.is_initializer()))?;
+        let own_ivars =
+            self._process_initialize(fullname, defs.iter().find(|d| d.is_initializer()))?;
         if !own_ivars.is_empty() {
             // Be careful not to reset ivars of corelib/* by builtin/*
             self.class_dict.define_ivars(fullname, own_ivars.clone())?;
@@ -330,12 +331,12 @@ impl HirMaker {
             .expect(&err)
             .clone();
 
-        self.push_ctx(HirMakerContext::method_ctx(
-            self.ctx(),
-            &signature,
-            is_initializer,
-            super_ivars.unwrap_or_else(HashMap::new),
-        ));
+        let method_ctx = if is_initializer {
+            HirMakerContext::initializer_ctx(self.ctx(), &signature, super_ivars.unwrap())
+        } else {
+            HirMakerContext::method_ctx(self.ctx(), &signature)
+        };
+        self.push_ctx(method_ctx);
         let body_exprs = self.convert_exprs(body_exprs)?;
         let mut method_ctx = self.pop_ctx();
         let lvars = method_ctx.extract_lvars();

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -21,6 +21,8 @@ pub struct HirMaker {
     pub(super) str_literals: Vec<String>,
     /// Stack of ctx
     pub(super) ctx_stack: Vec<HirMakerContext>,
+    /// Contextual information
+    pub(super) ctx: HirMakerContext_,
     /// Counter to give unique name for lambdas
     pub(super) lambda_ct: usize,
 }
@@ -51,6 +53,7 @@ impl HirMaker {
             const_inits: vec![],
             str_literals: vec![],
             ctx_stack: vec![],
+            ctx: HirMakerContext_::new(),
             lambda_ct: 0,
         }
     }

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -321,9 +321,9 @@ impl HirMaker {
             .clone();
 
         let method_ctx = if is_initializer {
-            HirMakerContext::initializer_ctx(self.ctx(), &signature, super_ivars.unwrap())
+            HirMakerContext::initializer_ctx(self.ctx(), signature.clone(), super_ivars.unwrap())
         } else {
-            HirMakerContext::method_ctx(self.ctx(), &signature)
+            HirMakerContext::method_ctx(self.ctx(), signature.clone())
         };
         self.push_ctx(method_ctx);
         let body_exprs = self.convert_exprs(body_exprs)?;

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -130,7 +130,7 @@ impl HirMaker {
         defs: &[ast::Definition],
     ) -> Result<(), Error> {
         let meta_name = fullname.meta_name();
-        let ctx = HirMakerContext::class_ctx(&fullname, self.next_ctx_depth());
+        let ctx = HirMakerContext::class_ctx(self.next_ctx_depth());
         self.push_ctx(ctx);
         let orig_current = self.ctx.current.clone();
         self.ctx.current = CtxKind::Class;
@@ -281,9 +281,8 @@ impl HirMaker {
         name: &ConstFirstname,
         expr: &AstExpression,
     ) -> Result<ConstFullname, Error> {
-        let ctx = self.ctx();
         // TODO: resolve name using ctx
-        let fullname = const_fullname(&format!("{}::{}", ctx.namespace.0, &name.0));
+        let fullname = const_fullname(&format!("{}::{}", self.ctx.namespace(), &name.0));
         let hir_expr = self.convert_expr(expr)?;
         Ok(self.register_const_full(fullname, hir_expr))
     }

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -324,12 +324,12 @@ impl HirMaker {
             .clone();
 
         let method_ctx = if is_initializer {
-            HirMakerContext::initializer_ctx(self.ctx(), signature.clone())
+            HirMakerContext::initializer_ctx(self.ctx())
         } else {
-            HirMakerContext::method_ctx(self.ctx(), signature.clone())
+            HirMakerContext::method_ctx(self.ctx())
         };
         self.push_ctx(method_ctx);
-        self.ctx.method = Some(MethodCtx::new(super_ivars));
+        self.ctx.method = Some(MethodCtx::new(signature.clone(), super_ivars));
         let body_exprs = self.convert_exprs(body_exprs)?;
         let iivars = self.ctx.method.take().unwrap().iivars;
         let mut method_ctx = self.pop_ctx();

--- a/src/hir/hir_maker.rs
+++ b/src/hir/hir_maker.rs
@@ -324,19 +324,16 @@ impl HirMaker {
             .clone();
 
         let method_ctx = if is_initializer {
-            HirMakerContext::initializer_ctx(self.ctx(), signature.clone(), super_ivars.unwrap())
+            HirMakerContext::initializer_ctx(self.ctx(), signature.clone())
         } else {
             HirMakerContext::method_ctx(self.ctx(), signature.clone())
         };
         self.push_ctx(method_ctx);
+        self.ctx.method = Some(MethodCtx::new(super_ivars));
         let body_exprs = self.convert_exprs(body_exprs)?;
+        let iivars = self.ctx.method.take().unwrap().iivars;
         let mut method_ctx = self.pop_ctx();
         let lvars = method_ctx.extract_lvars();
-        let iivars = if let CtxDetail::Initializer { iivars, .. } = method_ctx.detail {
-            iivars
-        } else {
-            Default::default()
-        };
         type_checking::check_return_value(&self.class_dict, &signature, &body_exprs.ty)?;
 
         let body = SkMethodBody::ShiikaMethodBody { exprs: body_exprs };

--- a/src/hir/hir_maker_context.rs
+++ b/src/hir/hir_maker_context.rs
@@ -16,8 +16,6 @@ pub struct HirMakerContext {
     pub method_sig: Option<MethodSignature>,
     /// The type of current `self`
     pub self_ty: TermTy,
-    /// Names of the type parameter of the current class (or method, in the future)
-    pub typarams: Vec<String>,
     /// Current namespace
     /// `""` for toplevel
     pub namespace: ClassFullname,
@@ -83,7 +81,6 @@ impl HirMakerContext {
             depth: 0,
             method_sig: None,
             self_ty: ty::raw("Object"),
-            typarams: vec![],
             namespace: ClassFullname("".to_string()),
             lvars: HashMap::new(),
             captures: vec![],
@@ -92,17 +89,12 @@ impl HirMakerContext {
     }
 
     /// Create a class context
-    pub fn class_ctx(
-        fullname: &ClassFullname,
-        typarams: Vec<String>,
-        depth: usize,
-    ) -> HirMakerContext {
+    pub fn class_ctx(fullname: &ClassFullname, depth: usize) -> HirMakerContext {
         HirMakerContext {
             kind: CtxKind::Class,
             depth,
             method_sig: None,
             self_ty: ty::raw("Object"),
-            typarams,
             namespace: fullname.clone(),
             lvars: HashMap::new(),
             captures: vec![],
@@ -121,7 +113,6 @@ impl HirMakerContext {
             depth: class_ctx.depth + 1,
             method_sig: Some(method_sig.clone()),
             self_ty: ty::raw(&class_ctx.namespace.0),
-            typarams: vec![],
             namespace: class_ctx.namespace.clone(),
             lvars: HashMap::new(),
             captures: vec![],
@@ -140,7 +131,6 @@ impl HirMakerContext {
             depth: class_ctx.depth + 1,
             method_sig: Some(method_sig.clone()),
             self_ty: ty::raw(&class_ctx.namespace.0),
-            typarams: vec![],
             namespace: class_ctx.namespace.clone(),
             lvars: HashMap::new(),
             captures: vec![],
@@ -164,7 +154,6 @@ impl HirMakerContext {
             depth: method_ctx.depth + 1,
             method_sig: Some(sig),
             self_ty: method_ctx.self_ty.clone(),
-            typarams: vec![],
             namespace: method_ctx.namespace.clone(),
             lvars: HashMap::new(),
             captures: vec![],

--- a/src/hir/hir_maker_context.rs
+++ b/src/hir/hir_maker_context.rs
@@ -25,7 +25,6 @@ pub struct HirMakerContext {
     pub lvars: HashMap<String, CtxLVar>,
     /// List of free variables captured in this context
     pub captures: Vec<LambdaCapture>,
-
     //
     // ivar-related stuffs
     //
@@ -33,10 +32,22 @@ pub struct HirMakerContext {
     pub iivars: SkIVars,
     /// Number of inherited ivars. Only used when kind is Initializer
     pub super_ivars: SkIVars, // TODO: this can be just &'a SkIVars
+
+    /// Additional information
+    pub body: CtxBody,
 }
 
 #[derive(Debug, PartialEq)]
 pub enum CtxKind {
+    Toplevel,
+    Class,
+    Method,
+    Initializer,
+    Lambda,
+}
+
+#[derive(Debug)]
+pub enum CtxBody {
     Toplevel,
     Class,
     Method,
@@ -80,6 +91,7 @@ impl HirMakerContext {
             captures: vec![],
             iivars: HashMap::new(),
             super_ivars: HashMap::new(),
+            body: CtxBody::Toplevel,
         }
     }
 
@@ -100,6 +112,7 @@ impl HirMakerContext {
             captures: vec![],
             iivars: HashMap::new(),
             super_ivars: HashMap::new(),
+            body: CtxBody::Class,
         }
     }
 
@@ -120,6 +133,7 @@ impl HirMakerContext {
             captures: vec![],
             iivars: HashMap::new(),
             super_ivars: HashMap::new(),
+            body: CtxBody::Method,
         }
     }
 
@@ -140,6 +154,7 @@ impl HirMakerContext {
             captures: vec![],
             iivars: HashMap::new(),
             super_ivars,
+            body: CtxBody::Initializer,
         }
     }
 
@@ -162,6 +177,7 @@ impl HirMakerContext {
             captures: vec![],
             iivars: HashMap::new(),
             super_ivars: HashMap::new(),
+            body: CtxBody::Lambda,
         }
     }
 

--- a/src/hir/hir_maker_context.rs
+++ b/src/hir/hir_maker_context.rs
@@ -22,7 +22,7 @@ pub struct HirMakerContext {
     /// Current local variables
     pub lvars: HashMap<String, CtxLVar>,
     /// Additional information
-    pub body: CtxBody,
+    pub detail: CtxDetail,
 }
 
 #[derive(Debug, PartialEq)]
@@ -35,7 +35,7 @@ pub enum CtxKind {
 }
 
 #[derive(Debug)]
-pub enum CtxBody {
+pub enum CtxDetail {
     Toplevel,
     Class,
     Method,
@@ -83,7 +83,7 @@ impl HirMakerContext {
             self_ty: ty::raw("Object"),
             namespace: ClassFullname("".to_string()),
             lvars: HashMap::new(),
-            body: CtxBody::Toplevel,
+            detail: CtxDetail::Toplevel,
         }
     }
 
@@ -96,7 +96,7 @@ impl HirMakerContext {
             self_ty: ty::raw("Object"),
             namespace: fullname.clone(),
             lvars: HashMap::new(),
-            body: CtxBody::Class,
+            detail: CtxDetail::Class,
         }
     }
 
@@ -113,7 +113,7 @@ impl HirMakerContext {
             self_ty: ty::raw(&class_ctx.namespace.0),
             namespace: class_ctx.namespace.clone(),
             lvars: HashMap::new(),
-            body: CtxBody::Method,
+            detail: CtxDetail::Method,
         }
     }
 
@@ -130,7 +130,7 @@ impl HirMakerContext {
             self_ty: ty::raw(&class_ctx.namespace.0),
             namespace: class_ctx.namespace.clone(),
             lvars: HashMap::new(),
-            body: CtxBody::Initializer {
+            detail: CtxDetail::Initializer {
                 iivars: HashMap::new(),
                 super_ivars,
             },
@@ -152,7 +152,7 @@ impl HirMakerContext {
             self_ty: method_ctx.self_ty.clone(),
             namespace: method_ctx.namespace.clone(),
             lvars: HashMap::new(),
-            body: CtxBody::Lambda { captures: vec![] },
+            detail: CtxDetail::Lambda { captures: vec![] },
         }
     }
 
@@ -180,21 +180,21 @@ impl HirMakerContext {
     // Methods for CtxKind::Lambda
     // QUESTION: is there a better way?
     pub fn captures(&self) -> &Vec<LambdaCapture> {
-        if let CtxBody::Lambda { captures } = &self.body {
+        if let CtxDetail::Lambda { captures } = &self.detail {
             &captures
         } else {
             panic!("this ctx is not Lambda")
         }
     }
     pub fn push_capture(&mut self, cap: LambdaCapture) {
-        if let CtxBody::Lambda { captures } = &mut self.body {
+        if let CtxDetail::Lambda { captures } = &mut self.detail {
             captures.push(cap);
         } else {
             panic!("this ctx is not Lambda")
         }
     }
     pub fn extract_captures(self) -> Vec<LambdaCapture> {
-        if let CtxBody::Lambda { captures } = self.body {
+        if let CtxDetail::Lambda { captures } = self.detail {
             captures
         } else {
             panic!("this ctx is not Lambda")

--- a/src/hir/hir_maker_context.rs
+++ b/src/hir/hir_maker_context.rs
@@ -11,9 +11,6 @@ pub struct HirMakerContext {
     pub kind: CtxKind,
     /// Where this ctx is in the ctx_stack
     pub depth: usize,
-    /// Current namespace
-    /// `""` for toplevel
-    pub namespace: ClassFullname,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -45,6 +42,15 @@ impl HirMakerContext_ {
             classes: vec![],
             method: None,
             lambdas: vec![],
+        }
+    }
+
+    /// Returns the current namespace
+    pub fn namespace(&self) -> &str {
+        if let Some(class_ctx) = self.classes.last() {
+            &class_ctx.namespace.0
+        } else {
+            ""
         }
     }
 
@@ -291,16 +297,14 @@ impl HirMakerContext {
         HirMakerContext {
             kind: CtxKind::Toplevel,
             depth: 0,
-            namespace: ClassFullname("".to_string()),
         }
     }
 
     /// Create a class context
-    pub fn class_ctx(fullname: &ClassFullname, depth: usize) -> HirMakerContext {
+    pub fn class_ctx(depth: usize) -> HirMakerContext {
         HirMakerContext {
             kind: CtxKind::Class,
             depth,
-            namespace: fullname.clone(),
         }
     }
 
@@ -309,7 +313,6 @@ impl HirMakerContext {
         HirMakerContext {
             kind: CtxKind::Method,
             depth: class_ctx.depth + 1,
-            namespace: class_ctx.namespace.clone(),
         }
     }
 
@@ -318,7 +321,6 @@ impl HirMakerContext {
         HirMakerContext {
             kind: CtxKind::Initializer,
             depth: class_ctx.depth + 1,
-            namespace: class_ctx.namespace.clone(),
         }
     }
 
@@ -327,7 +329,6 @@ impl HirMakerContext {
         HirMakerContext {
             kind: CtxKind::Lambda,
             depth: method_ctx.depth + 1,
-            namespace: method_ctx.namespace.clone(),
         }
     }
 }

--- a/src/hir/hir_maker_context.rs
+++ b/src/hir/hir_maker_context.rs
@@ -14,7 +14,7 @@ pub enum CtxKind {
 }
 
 #[derive(Debug)]
-pub struct HirMakerContext_ {
+pub struct HirMakerContext {
     /// Which kind of scope we're in
     pub current: CtxKind,
     // Context of each scope
@@ -24,10 +24,10 @@ pub struct HirMakerContext_ {
     pub lambdas: Vec<LambdaCtx>,
 }
 
-impl HirMakerContext_ {
+impl HirMakerContext {
     /// Create initial ctx
-    pub fn new() -> HirMakerContext_ {
-        HirMakerContext_ {
+    pub fn new() -> HirMakerContext {
+        HirMakerContext {
             current: CtxKind::Toplevel,
             toplevel: ToplevelCtx::new(),
             classes: vec![],
@@ -109,13 +109,13 @@ impl HirMakerContext_ {
 
 /// Iterates over each lvar scope.
 pub struct LVarIter<'a> {
-    ctx: &'a HirMakerContext_,
+    ctx: &'a HirMakerContext,
     cur: Option<CtxKind>,
     idx: usize,
 }
 
 impl<'a> LVarIter<'a> {
-    fn new(ctx: &HirMakerContext_) -> LVarIter {
+    fn new(ctx: &HirMakerContext) -> LVarIter {
         let idx = match ctx.current {
             CtxKind::Toplevel => 0,
             CtxKind::Class => ctx.classes.len() - 1,

--- a/src/hir/hir_maker_context.rs
+++ b/src/hir/hir_maker_context.rs
@@ -5,14 +5,6 @@ use crate::ty;
 use crate::ty::*;
 use std::collections::HashMap;
 
-#[derive(Debug)]
-pub struct HirMakerContext {
-    /// Type of this ctx
-    pub kind: CtxKind,
-    /// Where this ctx is in the ctx_stack
-    pub depth: usize,
-}
-
 #[derive(Debug, PartialEq, Clone)]
 pub enum CtxKind {
     Toplevel,
@@ -294,59 +286,7 @@ pub enum LambdaCaptureDetail {
     CapFnArg { idx: usize },
 }
 
-impl HirMakerContext {
-    /// Create a ctx for toplevel
-    pub fn toplevel() -> HirMakerContext {
-        // REVIEW: not sure this 'static is the right way
-        HirMakerContext {
-            kind: CtxKind::Toplevel,
-            depth: 0,
-        }
-    }
-
-    /// Create a class context
-    pub fn class_ctx(depth: usize) -> HirMakerContext {
-        HirMakerContext {
-            kind: CtxKind::Class,
-            depth,
-        }
-    }
-
-    /// Create a method context
-    pub fn method_ctx(class_ctx: &HirMakerContext) -> HirMakerContext {
-        HirMakerContext {
-            kind: CtxKind::Method,
-            depth: class_ctx.depth + 1,
-        }
-    }
-
-    /// Create a ctx for lambda
-    pub fn lambda_ctx(method_ctx: &HirMakerContext) -> HirMakerContext {
-        HirMakerContext {
-            kind: CtxKind::Lambda,
-            depth: method_ctx.depth + 1,
-        }
-    }
-}
-
 impl HirMaker {
-    pub(super) fn ctx(&self) -> &HirMakerContext {
-        self.ctx_stack.last().unwrap()
-    }
-
-    pub(super) fn push_ctx(&mut self, ctx: HirMakerContext) {
-        self.ctx_stack.push(ctx);
-    }
-
-    pub(super) fn pop_ctx(&mut self) -> HirMakerContext {
-        self.ctx_stack.pop().unwrap()
-    }
-
-    /// Returns depth of next ctx
-    pub(super) fn next_ctx_depth(&self) -> usize {
-        self.ctx_stack.len()
-    }
-
     /// Returns type parameter of the current class
     pub(super) fn current_class_typarams(&self) -> Vec<String> {
         let typarams = &self

--- a/src/hir/hir_maker_context.rs
+++ b/src/hir/hir_maker_context.rs
@@ -50,6 +50,34 @@ impl HirMakerContext_ {
         }
     }
 
+    /// Return local variable of given name, if any
+    pub fn find_lvar(&self, name: &str) -> Option<&CtxLVar> {
+        let lvars = match self.current {
+            CtxKind::Toplevel => self.toplevel.lvars,
+            CtxKind::Class => self.classes.last().as_ref().unwrap().lvars,
+            CtxKind::Method => self.method.as_ref().unwrap().lvars,
+            CtxKind::Lambda => self.lambdas.last().as_ref().unwrap().lvars,
+        };
+        lvars.get(name)
+    }
+
+    /// Add a local variable to current context
+    pub fn declare_lvar(&mut self, name: &str, ty: TermTy, readonly: bool) {
+        let lvars = match self.current {
+            CtxKind::Toplevel => self.toplevel.lvars,
+            CtxKind::Class => self.classes.last().as_ref().unwrap().lvars,
+            CtxKind::Method => self.method.as_ref().unwrap().lvars,
+            CtxKind::Lambda => self.lambdas.last().as_ref().unwrap().lvars,
+        };
+        let k = name.to_string();
+        let v = CtxLVar {
+            name: name.to_string(),
+            ty,
+            readonly,
+        };
+        lvars.insert(k, v);
+    }
+
     /// Return method/lambda argument of given name, if any
     pub fn find_fn_arg(&self, name: &str) -> Option<(usize, &MethodParam)> {
         let params = if let Some(lambda_ctx) = self.lambdas.last() {
@@ -231,11 +259,6 @@ impl HirMakerContext {
             self_ty: method_ctx.self_ty.clone(),
             namespace: method_ctx.namespace.clone(),
         }
-    }
-
-    /// Return local variable of given name, if any
-    pub fn find_lvar(&self, name: &str) -> Option<&CtxLVar> {
-        self.lvars.get(name)
     }
 }
 

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -223,7 +223,6 @@ pub enum HirExpressionBase {
     },
     /// Reassign to a variable in `captures`
     HirLambdaCaptureWrite {
-        arity: usize,
         cidx: usize,
         rhs: Box<HirExpression>,
     },
@@ -490,11 +489,10 @@ impl Hir {
         }
     }
 
-    pub fn lambda_capture_write(arity: usize, cidx: usize, rhs: HirExpression) -> HirExpression {
+    pub fn lambda_capture_write(cidx: usize, rhs: HirExpression) -> HirExpression {
         HirExpression {
             ty: rhs.ty.clone(),
             node: HirExpressionBase::HirLambdaCaptureWrite {
-                arity,
                 cidx,
                 rhs: Box::new(rhs),
             },

--- a/src/hir/signature.rs
+++ b/src/hir/signature.rs
@@ -12,14 +12,6 @@ pub struct MethodSignature {
 }
 
 impl MethodSignature {
-    /// Return a param of the given name and its index
-    pub fn find_param(&self, name: &str) -> Option<(usize, &MethodParam)> {
-        self.params
-            .iter()
-            .enumerate()
-            .find(|(_, param)| param.name == name)
-    }
-
     pub fn first_name(&self) -> &MethodFirstname {
         &self.fullname.first_name
     }
@@ -52,6 +44,14 @@ impl MethodParam {
             ty: self.ty.substitute(class_tyargs, method_tyargs),
         }
     }
+}
+
+/// Return a param of the given name and its index
+pub fn find_param<'a>(params: &'a [MethodParam], name: &str) -> Option<(usize, &'a MethodParam)> {
+    params
+        .iter()
+        .enumerate()
+        .find(|(_, param)| param.name == name)
 }
 
 /// Create `hir::MethodSignature` from `ast::MethodSignature`


### PR DESCRIPTION
Current `HirMakerContext` has union of members which are needed in each situation. This PR split it into `ToplevelCtx` `ClassCtx` `MethodCtx` `LambdaCtx`.