### PR TITLE
Add HIR for lambda invocation

### DIFF
--- a/doc/guide/src/SUMMARY.md
+++ b/doc/guide/src/SUMMARY.md
@@ -9,5 +9,4 @@
   - Basic Types
 - [Classes and Objects](./classes.md)
 - [Expressions](./expressions.md)
-- Functions and Blocks
 - FAQ

--- a/doc/guide/src/expressions.md
+++ b/doc/guide/src/expressions.md
@@ -47,13 +47,13 @@ Reassigning to `x` only allowed for the latter form.
 
 An instance of the classes `Fn0`, `Fn1`, ..., `Fn9` is called a _lambda_. Lambdas can be created by _lambda expression_.
 
-- `fn(){ p 1 }` evaluates to an instance of `Fn0<Void>`
+- `fn{ p 1 }` evaluates to an instance of `Fn0<Void>`
 - `fn(x: Int){ p x }` evaluates to an instance of `Fn1<Int, Void>`
 
 ### Invoking a function
 
 ```sk
-f = fn(){ p 1 }
+f = fn{ p 1 }
 f()
 ```
 
@@ -61,7 +61,7 @@ Note that you need to assign it to a variable to invoke it. You cannot do this:
 
 ```sk
 # NG
-(fn(){ p 1 })()
+(fn{ p 1 })()
 ```
 
 ## Method call

--- a/doc/guide/src/expressions.md
+++ b/doc/guide/src/expressions.md
@@ -47,17 +47,22 @@ Reassigning to `x` only allowed for the latter form.
 
 An instance of the classes `Fn0`, `Fn1`, ..., `Fn9` is called a _lambda_. Lambdas can be created by _lambda expression_.
 
-- `fn{ p 1 }` evaluates to an instance of `Fn0<Void>`
+- `fn(){ p 1 }` evaluates to an instance of `Fn0<Void>`
 - `fn(x: Int){ p x }` evaluates to an instance of `Fn1<Int, Void>`
 
 ### Invoking a function
 
 ```sk
-f = fn{ p 1 }
-f.call
+f = fn(){ p 1 }
+f()
 ```
 
-TODO: `f()` should also be ok https://github.com/yhara/shiika/issues/264
+Note that you need to assign it to a variable to invoke it. You cannot do this:
+
+```sk
+# NG
+(fn(){ p 1 })()
+```
 
 ## Method call
 

--- a/doc/spec/src/expressions.md
+++ b/doc/spec/src/expressions.md
@@ -47,17 +47,17 @@ Reassigning to `x` only allowed for the latter form.
 
 An instance of the classes `Fn0`, `Fn1`, ..., `Fn9` is called a _lambda_. Lambdas can be created by _lambda expression_.
 
-- `fn{ p 1 }` evaluates to an instance of `Fn0<Void>`
+- `fn(){ p 1 }` evaluates to an instance of `Fn0<Void>`
 - `fn(x: Int){ p x }` evaluates to an instance of `Fn1<Int, Void>`
 
 ### Invoking a function
 
 ```sk
-f = fn{ p 1 }
-f.call
+f = fn(){ p 1 }
+f()
 ```
 
-TODO: `f()` should also be ok https://github.com/yhara/shiika/issues/264
+`f` must be an instance of `Fn`.
 
 ## Method call
 

--- a/doc/spec/src/expressions.md
+++ b/doc/spec/src/expressions.md
@@ -47,13 +47,13 @@ Reassigning to `x` only allowed for the latter form.
 
 An instance of the classes `Fn0`, `Fn1`, ..., `Fn9` is called a _lambda_. Lambdas can be created by _lambda expression_.
 
-- `fn(){ p 1 }` evaluates to an instance of `Fn0<Void>`
+- `fn{ p 1 }` evaluates to an instance of `Fn0<Void>`
 - `fn(x: Int){ p x }` evaluates to an instance of `Fn1<Int, Void>`
 
 ### Invoking a function
 
 ```sk
-f = fn(){ p 1 }
+f = fn{ p 1 }
 f()
 ```
 

--- a/src/code_gen/lambda.rs
+++ b/src/code_gen/lambda.rs
@@ -75,6 +75,12 @@ impl<'hir: 'ictx, 'run, 'ictx: 'run> CodeGen<'hir, 'run, 'ictx> {
                     self.gen_lambda_funcs_in_expr(expr)?;
                 }
             }
+            HirLambdaInvocation { lambda_expr, arg_exprs } => {
+                self.gen_lambda_funcs_in_expr(lambda_expr)?;
+                for expr in arg_exprs {
+                    self.gen_lambda_funcs_in_expr(expr)?;
+                }
+            }
             HirArgRef { .. } => (),
             HirLVarRef { .. } => (),
             HirIVarRef { .. } => (),

--- a/src/corelib/fn_x.rs
+++ b/src/corelib/fn_x.rs
@@ -1,63 +1,4 @@
 use crate::corelib::*;
-use inkwell::types::*;
-use inkwell::AddressSpace;
-
-/// Index of @func of FnX
-const FN_X_FUNC_IDX: usize = 0;
-
-macro_rules! create_fn_call {
-    ($i:expr) => {{
-        let args_str = (1..=$i)
-            .map(|i| format!("arg{}: S{}", i, i))
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        let mut typarams = (1..=$i).map(|i| format!("S{}", i)).collect::<Vec<_>>();
-        typarams.push("T".to_string());
-
-        create_method_generic(
-            &format!("Fn{}", $i),
-            &format!("call({}) -> T", args_str),
-            |code_gen, function| {
-                let fn_obj = function.get_params()[0];
-                let sk_ptr = code_gen.build_ivar_load(fn_obj, FN_X_FUNC_IDX, "@func");
-
-                let mut args = vec![fn_obj];
-                for k in 1..=$i {
-                    args.push(function.get_params()[k]);
-                }
-
-                // Create the type of lambda_xx()
-                let fn_x_type = code_gen.llvm_type(&ty::raw(&format!("Fn{}", $i)));
-                let obj_type = code_gen.llvm_type(&ty::raw("Object"));
-                let mut arg_types = vec![fn_x_type.into()];
-                for _ in 1..=$i {
-                    arg_types.push(obj_type.into());
-                }
-                let fntype = obj_type.fn_type(&arg_types, false);
-                let fnptype = fntype.ptr_type(AddressSpace::Generic);
-
-                // Cast `fnptr` to that type
-                let fnptr = code_gen.unbox_i8ptr(sk_ptr);
-                let func = code_gen
-                    .builder
-                    .build_bitcast(fnptr, fnptype, "")
-                    .into_pointer_value();
-
-                // Generate function call
-                let result = code_gen
-                    .builder
-                    .build_call(func, &args, "result")
-                    .try_as_basic_value()
-                    .left()
-                    .unwrap();
-                code_gen.builder.build_return(Some(&result));
-                Ok(())
-            },
-            &typarams,
-        )
-    }};
-}
 
 macro_rules! fn_item {
     ($i:expr) => {{
@@ -67,7 +8,7 @@ macro_rules! fn_item {
         (
             format!("Fn{}", $i),
             Some(class_fullname("Fn")),
-            vec![create_fn_call!($i)],
+            vec![],
             vec![],
             ivars(),
             typarams,

--- a/src/hir/convert_exprs.rs
+++ b/src/hir/convert_exprs.rs
@@ -392,8 +392,8 @@ impl HirMaker {
         // Check if this is a lambda invocation
         if receiver_expr.is_none() {
             if let Some(lvar) = self._lookup_var(&method_name.0) {
-                if let Some((ret_ty, method_fullname)) = lvar.ty().fn_x_info() {
-                    return Ok(Hir::method_call(ret_ty, lvar.ref_expr(), method_fullname, arg_hirs));
+                if let Some(ret_ty) = lvar.ty().fn_x_info() {
+                    return Ok(Hir::lambda_invocation(ret_ty, lvar.ref_expr(), arg_hirs));
                 }
             }
         }

--- a/src/hir/mod.rs
+++ b/src/hir/mod.rs
@@ -179,6 +179,10 @@ pub enum HirExpressionBase {
         method_fullname: MethodFullname,
         arg_exprs: Vec<HirExpression>,
     },
+    HirLambdaInvocation {
+        lambda_expr: Box<HirExpression>,
+        arg_exprs: Vec<HirExpression>,
+    },
     HirArgRef {
         idx: usize,
     },
@@ -404,17 +408,15 @@ impl Hir {
         }
     }
 
-    pub fn invoke_lambda(
+    pub fn lambda_invocation(
         result_ty: TermTy,
-        receiver_hir: HirExpression,
-        method_fullname: MethodFullname,
+        varref_expr: HirExpression,
         arg_hirs: Vec<HirExpression>,
     ) -> HirExpression {
         HirExpression {
             ty: result_ty,
-            node: HirExpressionBase::HirMethodCall {
-                receiver_expr: Box::new(receiver_hir),
-                method_fullname,
+            node: HirExpressionBase::HirLambdaInvocation {
+                lambda_expr: Box::new(varref_expr),
                 arg_exprs: arg_hirs,
             },
         }

--- a/src/names.rs
+++ b/src/names.rs
@@ -110,16 +110,6 @@ impl std::fmt::Display for MethodFullname {
 }
 
 impl MethodFullname {
-    /// Returns true if this is any of `Fn0#call`, ..., `Fn9#call`
-    pub fn is_fn_x_call(&self) -> bool {
-        for i in 0..=9 {
-            if self.full_name == format!("Fn{}#call", i) {
-                return true;
-            }
-        }
-        false
-    }
-
     /// Returns true if this method isn't an instance method
     pub fn is_class_method(&self) -> bool {
         self.full_name.starts_with("Meta:")

--- a/src/parser/expression_parser.rs
+++ b/src/parser/expression_parser.rs
@@ -870,11 +870,15 @@ impl<'a> Parser<'a> {
         self.lv += 1;
         self.debug_log("parse_lambda");
         assert!(self.consume(Token::KwFn));
-        self.expect(Token::LParen)?;
-        let params = self.parse_params(false, vec![Token::RParen])?;
+        let params;
+        if self.consume(Token::LParen) {
+            params = self.parse_params(false, vec![Token::RParen])?;
+            self.skip_ws();
+        } else {
+            params = vec![];
+        }
         self.skip_ws();
         self.expect(Token::LBrace)?;
-        self.consume_token();
         let exprs = self.parse_exprs(vec![Token::RBrace])?;
         assert!(self.consume(Token::RBrace));
         self.lv -= 1;

--- a/src/parser/expression_parser.rs
+++ b/src/parser/expression_parser.rs
@@ -100,6 +100,7 @@ impl<'a> Parser<'a> {
             Token::LowerWord(_) | Token::KwReturn => {
                 if self.peek_next_token() == Token::Space {
                     if let Some(expr) = self._try_parse_call_wo_paren()? {
+                        self.lv -= 1;
                         return Ok(expr)
                     }
                 }
@@ -108,7 +109,7 @@ impl<'a> Parser<'a> {
         }
 
         // If not, read an expression
-        let expr = self.parse_operator_expr()?;
+        let mut expr = self.parse_operator_expr()?;
 
         // See if it is a method invocation (eg. `x.foo 1, 2`)
         if expr.may_have_paren_wo_args() {
@@ -118,12 +119,11 @@ impl<'a> Parser<'a> {
                 if let Some(lambda) = self.parse_opt_do_block()? {
                     args.push(lambda);
                 }
-                self.lv -= 1;
-                return Ok(ast::set_method_call_args(expr, args));
+                expr = ast::set_method_call_args(expr, args);
             } else if self.next_nonspace_token() == Token::KwDo {
                 self.skip_ws();
                 let lambda = self.parse_do_block()?;
-                return Ok(ast::set_method_call_args(expr, vec![lambda]));
+                expr = ast::set_method_call_args(expr, vec![lambda]);
             }
         }
 
@@ -148,7 +148,6 @@ impl<'a> Parser<'a> {
             if let Some(lambda) = self.parse_opt_do_block()? {
                 args.push(lambda);
             }
-            self.lv -= 1;
             match &token {
                 Token::LowerWord(s) => {
                     return Ok(Some(ast::method_call(None, &s, args, vec![], false, false)));
@@ -197,13 +196,12 @@ impl<'a> Parser<'a> {
     fn parse_operator_expr(&mut self) -> Result<AstExpression, Error> {
         self.lv += 1;
         self.debug_log("parse_operator_expr");
-        let expr = self.parse_conditional_expr()?;
+        let mut expr = self.parse_conditional_expr()?;
         if expr.is_lhs() && self.next_nonspace_token().is_assignment_token() {
-            self.parse_assignment_expr(expr)
-        } else {
-            self.lv -= 1;
-            Ok(expr)
+            expr = self.parse_assignment_expr(expr)?;
         }
+        self.lv -= 1;
+        Ok(expr)
     }
 
     // assignmentExpression:
@@ -487,6 +485,7 @@ impl<'a> Parser<'a> {
         self.lv += 1;
         self.debug_log("parse_break_expr");
         assert!(self.consume(Token::KwBreak));
+        self.lv -= 1;
         Ok(ast::break_expr())
     }
 
@@ -567,12 +566,11 @@ impl<'a> Parser<'a> {
         let then_exprs = self.parse_exprs(vec![Token::KwEnd, Token::KwElse])?;
         self.skip_wsn();
         if self.consume(Token::KwElse) {
-            Err(parse_error!(self, "unless cannot have a else clause"))
-        } else {
-            self.expect(Token::KwEnd)?;
-            self.lv -= 1;
-            Ok(ast::if_expr(ast::logical_not(cond_expr), then_exprs, None))
+            return Err(parse_error!(self, "unless cannot have a else clause"));
         }
+        self.expect(Token::KwEnd)?;
+        self.lv -= 1;
+        Ok(ast::if_expr(ast::logical_not(cond_expr), then_exprs, None))
     }
 
     fn parse_while_expr(&mut self) -> Result<AstExpression, Error> {

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -135,15 +135,14 @@ impl TermTy {
         }
     }
 
-    // Returns (ret_ty, method_fullname) if this is any of Fn0, .., Fn9
-    pub fn fn_x_info(&self) -> Option<(TermTy, MethodFullname)> {
+    // Returns ret_ty if this is any of Fn0, .., Fn9
+    pub fn fn_x_info(&self) -> Option<TermTy> {
         match &self.body {
             TySpe { base_name, type_args } => {
                 for i in 0..=9 {
                     if *base_name == format!("Fn{}", i) {
                         let ret_ty = type_args.last().unwrap().clone();
-                        let method_name = method_fullname(&class_fullname(format!("Fn{}", i)), "call");
-                        return Some((ret_ty, method_name));
+                        return Some(ret_ty);
                     }
                 }
                 None

--- a/tests/sk/block.sk
+++ b/tests/sk/block.sk
@@ -1,7 +1,7 @@
 var result = 0
 class A
   def self.one(f: Fn1<Int,Int>) -> Int
-    f.call(1)
+    f(1)
   end
 end
 

--- a/tests/sk/lambda.sk
+++ b/tests/sk/lambda.sk
@@ -1,14 +1,16 @@
 # Basic
-if fn(){ false }.call; puts "ng 0"; end
-var f = fn(x: Int){ x + 1 }
-if f.call(1) != 2; puts "ng 1"; end
-ff = fn(x: Int, y: Int){ x + y }
-if ff.call(1, 2) != 3; puts "ng 1-1"; end
+var f0 = fn(){ false };
+if f0(); puts "ng 0"; end
+var f1 = fn(x: Int){ x + 1 }
+if f1(1) != 2; puts "ng 1"; end
+f2 = fn(x: Int, y: Int){ x + y }
+if f2(1, 2) != 3; puts "ng 1-1"; end
 
 # Lambda in a method
 class A
   def self.foo(i: Int) -> Int
-    fn(x: Int){ x + i }.call(1)
+    f = fn(x: Int){ x + i }
+    f(1)
   end
 end
 if A.foo(1) != 2; puts "ng 2"; end
@@ -20,19 +22,19 @@ g = fn(x: Int){
   h = fn(y: Int, z: Int) {
     a + b + x + y + z
   }
-  h.call(3, 4)
+  h(3, 4)
 }
-unless g.call(5) == 15; puts "ng 3"; end
+unless g(5) == 15; puts "ng 3"; end
 
 # Capturing bool
 t = true
-f2 = fn(x: Int) { t }
-unless f2.call(0); puts "ng 4"; end
+f1b = fn(x: Int) { t }
+unless f1b(0); puts "ng 4"; end
 
 # Updating value
 a = 0
-f = fn(x: Int) { a = 1 }
-f.call(0)
+f1 = fn(x: Int) { a = 1 }
+f1(0)
 unless a == 1; puts "ng 5"; end
 
 puts "ok"

--- a/tests/sk/lambda.sk
+++ b/tests/sk/lambda.sk
@@ -1,5 +1,5 @@
 # Basic
-var f0 = fn(){ false };
+var f0 = fn{ false };
 if f0(); puts "ng 0"; end
 var f1 = fn(x: Int){ x + 1 }
 if f1(1) != 2; puts "ng 1"; end

--- a/tests/sk/loops_and_conditionals.sk
+++ b/tests/sk/loops_and_conditionals.sk
@@ -64,7 +64,7 @@ class A
 
   def self.return_from_fn -> Int
     f = fn(){ return 1; 2 } # Jumps to the end of this fn
-    f.call
+    f()
   end
 end
 A.wo_arg


### PR DESCRIPTION
This PR adds `HirLambdaInvocation` and removes `FnX#call`.

## Motivation

- In #266, I'm adding an extra argument `exit_status` to method llvm func
  - If the method is terminated by "a block with return", it stores `EXIT_RETURN` to `exit_status`
- Then `break` should also be handled this way
- But it is impossible if a lambda is invoked by `FnX#call`
