### PR TITLE
Some more typo fixes and doc fix.

### DIFF
--- a/doc/guide/src/classes.md
+++ b/doc/guide/src/classes.md
@@ -36,7 +36,7 @@ class Book
 end
 ```
 
-For convenence, this can be written as:
+For convenience, this can be written as:
 
 ```sk
 class Book
@@ -44,11 +44,11 @@ class Book
 end
 ```
 
-Instance variables are readonly by default. To make it reassignable, declare it with `var`.
+Instance variables are read-only by default. To make it reassignable, declare it with `var`.
 
 ## Accessors
 
-For each instance variable, accessor methods are automatically defined. A reader method for an readonly one, reader and setter method for an writable one.
+For each instance variable, accessor methods are automatically defined. A reader method for an read-only one, reader and setter method for an writable one.
 
 Example
 

--- a/doc/guide/src/expressions.md
+++ b/doc/guide/src/expressions.md
@@ -118,8 +118,8 @@ The types of if branches must be the same, except `Void` (such as `puts`) and `N
 `x if y` is equivalent to
 
 ```sk
-if x
-  y
+if y
+  x
 end
 ```
 
@@ -146,8 +146,8 @@ Note: `unless` cannot take `elsif` or `else` clause.
 `x unless y` is equivalent to
 
 ```sk
-if !x
-  y
+if !y
+  x
 end
 ```
 


### PR DESCRIPTION
Convenience spelling fixed in classes.md, also readonly changed to read-only for better readability.
In expressions.md,
- for the if statement `x if y` it states that x should be done if y is true.
-  for the unless statement `x unless y` it states that x should be done until y becomes true
So, some semantic changes